### PR TITLE
Add verified one-command installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           mkdir -p dist
           find bin -type f -name 'xray-mitm-*.apk' -exec cp '{}' dist/ \;
           find bin -type f -name 'luci-app-xray-mitm-*.apk' -exec cp '{}' dist/ \;
-          cp LICENSE README.md README.fa.md THIRD_PARTY_NOTICES.md dist/
+          cp LICENSE README.md README.fa.md THIRD_PARTY_NOTICES.md install.sh dist/
           printf '%s\n' "$GITHUB_SHA" > dist/SOURCE_COMMIT
 
           test "$(find dist -maxdepth 1 -type f -name 'xray-mitm-*.apk' | wc -l)" -eq 1
@@ -79,6 +79,9 @@ jobs:
             | LC_ALL=C sort \
             | sed 's#^./##' \
             | xargs sha256sum > SHA256SUMS
+          find . -maxdepth 1 -type f -name '*.apk' -print \
+            | LC_ALL=C sort \
+            | sed 's#^./##' > PACKAGES
           sha256sum -c SHA256SUMS
 
       - name: Upload APK artifact

--- a/README.fa.md
+++ b/README.fa.md
@@ -9,23 +9,38 @@
 
 ## راه‌اندازی سریع
 
-### ۱. بررسی روتر
+### ۱. نصب با یک دستور
 
-وارد SSH روتر شوید و نسخه OpenWrt و مدیر بسته را بررسی کنید.
+بسته‌های منتشرشده به OpenWrt رسمی 25.12.5 یا جدیدتر با APK و بسته سازگار `xray-core` نیاز دارند. اگر آدرس روتر شما متفاوت است، `192.168.1.1` را تغییر دهید. سپس دستور مربوط به کامپیوتر خود را اجرا و رمز روتر را وارد کنید.
 
 **مک:**
 
 ```sh
-ssh root@192.168.1.1
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh'
 ```
 
 **کامپیوتر ویندوزی (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1
+ssh.exe root@192.168.1.1 "wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh"
 ```
 
-پس از اتصال، دستورهای زیر را روی روتر اجرا کنید:
+اگر از قبل با SSH وارد روتر شده‌اید، دستور کوتاه‌تر زیر را اجرا کنید:
+
+**روتر:**
+
+```sh
+wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh
+```
+
+نصب‌کننده روتر را بررسی می‌کند، آخرین GitHub Release را دریافت می‌کند، checksum هر دو APK را با `SHA256SUMS` می‌سنجد، هنگام ارتقا یک نسخه پشتیبان محافظت‌شده می‌سازد و بسته اصلی و LuCI را نصب می‌کند. این برنامه CA نمی‌سازد، سرویس را روشن نمی‌کند و مسیریابی PassWall2 را تغییر نمی‌دهد. این کارها همچنان به‌صورت شفاف در LuCI انجام می‌شوند.
+
+روتر باید به `raw.githubusercontent.com` و `github.com` از طریق HTTPS دسترسی داشته باشد. اگر این آدرس‌ها از روتر باز نمی‌شوند، از روش دستی زیر استفاده کنید تا فایل‌ها روی مک یا کامپیوتر ویندوزی دانلود و با SSH به روتر منتقل شوند.
+
+<details>
+<summary>روش دستی: دریافت و کپی فایل‌های انتشار</summary>
+
+ابتدا وجود APK و نسخه روتر را بررسی کنید:
 
 **روتر:**
 
@@ -34,10 +49,6 @@ ssh.exe root@192.168.1.1
 printf 'OpenWrt release: %s\n' "$DISTRIB_RELEASE"
 apk --version
 ```
-
-نسخه باید OpenWrt رسمی 25.12.5 یا جدیدتر باشد و دستور `apk` باید موجود باشد. مخزن‌های روتر نیز باید بسته سازگار `xray-core` را ارائه کنند.
-
-### ۲. دریافت فایل‌های انتشار
 
 از یک GitHub Release واحد، این سه فایل را دانلود کنید:
 
@@ -80,7 +91,7 @@ scp.exe -O $core $luci $sums root@192.168.1.1:/tmp/xray-mitm-install/
 
 اگر `Get-Command` این برنامه‌ها را پیدا نکرد، ابتدا **OpenSSH Client** را از Optional Features ویندوز نصب کنید. اگر آدرس روتر متفاوت است، `192.168.1.1` را تغییر دهید.
 
-### ۳. بررسی checksum و نصب
+checksum را بررسی و بسته‌ها را نصب کنید
 
 قبل از نصب، checksum هر دو بسته را بررسی کنید. اگر هرکدام خطا داد، نصب را ادامه ندهید.
 
@@ -95,7 +106,9 @@ apk add --allow-untrusted ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
 
 بسته‌های CI با کلیدی که روتر معمولی به آن اعتماد دارد امضا نشده‌اند؛ به همین دلیل پس از بررسی checksum از `--allow-untrusted` استفاده می‌شود.
 
-### ۴. پیکربندی اولیه در LuCI
+</details>
+
+### ۲. پیکربندی اولیه در LuCI
 
 نصب بسته به‌تنهایی سرویس را روشن نمی‌کند، CA نمی‌سازد و مسیریابی PassWall2 را تغییر نمی‌دهد.
 
@@ -128,7 +141,7 @@ certutil.exe -user -addstore -f Root .\mycert.crt
 
 دستور ویندوز CA را فقط برای کاربر فعلی trusted می‌کند. اگر Firefox از certificate store مستقل استفاده کند، باید `mycert.crt` را داخل خود Firefox نیز وارد کنید.
 
-### ۵. اتصال اختیاری به PassWall2
+### ۳. اتصال اختیاری به PassWall2
 
 اگر فقط خود سرویس و پراکسی محلی را می‌خواهید، این مرحله لازم نیست. برای مسیریابی شفاف دامنه‌ها:
 
@@ -145,7 +158,7 @@ certutil.exe -user -addstore -f Root .\mycert.crt
 - اگر ویدیوهای YouTube باید از مسیر سریع MITM عبور کنند، `googlevideo.com` را در `YouTube_Control_VPN` قرار ندهید؛ این دامنه باید در `Google_MITM` باقی بماند.
 - گزینه `localhost_proxy=0` مانع ورود دوباره خروجی Xray مستقل به PassWall2 و ایجاد حلقه می‌شود.
 
-### ۶. آزمایش از دستگاه کلاینت
+### ۴. آزمایش از دستگاه کلاینت
 
 پس از نصب `mycert.crt` روی مک، این آزمایش را اجرا کنید:
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,38 @@ This repository packages a standalone Xray MITM-DomainFronting service and a sma
 
 This is the shortest supported installation path. The sections below explain the design, routing options, building, upgrades, and removal in more detail.
 
-### 1. Check the router
+### 1. Install with one command
 
-The published packages require official OpenWrt 25.12.5 or later with APK and a compatible `xray-core` package.
+The published packages require official OpenWrt 25.12.5 or later with APK and a compatible `xray-core` package. Replace `192.168.1.1` if the router uses another address, then run the command for your computer. Enter the router password when prompted.
 
 **MAC:**
 
 ```sh
-ssh root@192.168.1.1
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh'
 ```
 
 **WINDOWS PC (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1
+ssh.exe root@192.168.1.1 "wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh"
 ```
 
-After connecting, run the following on the router:
+If you are already connected to the router through SSH, run the shorter router command:
+
+**ROUTER:**
+
+```sh
+wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh
+```
+
+The installer checks the router, downloads the latest GitHub Release, verifies both APKs against `SHA256SUMS`, makes a protected configuration backup during upgrades, and installs the core and LuCI packages. It does not create a CA, start the service, or change PassWall2 routing. Those actions remain explicit in LuCI.
+
+The router needs HTTPS access to `raw.githubusercontent.com` and `github.com`. If either address is unavailable from the router, use the manual alternative below to download on the Mac or Windows PC and copy the files over SSH.
+
+<details>
+<summary>Manual alternative: download and copy the release files</summary>
+
+Confirm the router uses APK:
 
 **ROUTER:**
 
@@ -36,8 +51,6 @@ After connecting, run the following on the router:
 printf 'OpenWrt release: %s\n' "$DISTRIB_RELEASE"
 apk --version
 ```
-
-### 2. Download and copy the release files
 
 Download both `.apk` files and `SHA256SUMS` from the same GitHub Release. Put them in one directory on the Mac, then create a protected temporary directory on the router.
 
@@ -70,9 +83,7 @@ scp.exe -O $core $luci $sums root@192.168.1.1:/tmp/xray-mitm-install/
 
 If the router uses another address, replace `192.168.1.1`. If `Get-Command` cannot find the programs, install **OpenSSH Client** from Windows Optional Features first.
 
-### 3. Verify and install
-
-Do not install if either checksum fails.
+Verify and install on the router. Do not continue if either checksum fails.
 
 **ROUTER:**
 
@@ -83,7 +94,9 @@ apk update
 apk add --allow-untrusted ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
 ```
 
-### 4. Complete setup in LuCI
+</details>
+
+### 2. Complete setup in LuCI
 
 1. Open LuCI over **HTTPS** and go to **Services → MITM Domain Fronting**.
 2. Select **Install packaged default configuration**.
@@ -112,13 +125,13 @@ certutil.exe -user -addstore -f Root .\mycert.crt
 
 The Windows command trusts the CA for the current user. Firefox may require a separate import if it is configured to use its own certificate store.
 
-### 5. Configure PassWall2 if needed
+### 3. Configure PassWall2 if needed
 
 PassWall2 integration is optional. Open the routing section in the LuCI page, choose the shunt and VPN nodes, preview the proposed changes, check the rule order, and then apply them.
 
 Higher rules take priority. A domain placed in `Android_Check`, `Gemini_VPN`, or `YouTube_Control_VPN` can override `Google_MITM`. If `www.google.com` should use MITM, it must not also appear in a higher VPN rule. Keep `googlevideo.com` out of `YouTube_Control_VPN` when YouTube video delivery should use the faster MITM path.
 
-### 6. Verify from a client
+### 4. Verify from a client
 
 **MAC:**
 
@@ -199,7 +212,7 @@ An interrupted routing transaction is restored automatically before a new previe
 
 The checked-in workflow validates the release tree, then builds both noarch APKs with the official OpenWrt SDK action. Its default is the OpenWrt 25.12.5 `aarch64_generic` SDK; a manual run can select another official SDK architecture or later OpenWrt release. Because both packages declare `all`, the output APKs contain no target-native program.
 
-From GitHub, open **Actions → Build OpenWrt APKs → Run workflow**. Set the SDK architecture and release to match a supported official SDK container. The result contains both APKs, `SHA256SUMS`, the license and attribution files, and `SOURCE_COMMIT` identifying the exact source revision. CI artifacts are development packages and are not signed by a key trusted by a stock router; verify their checksums and use `--allow-untrusted` only when you trust the repository and workflow run.
+From GitHub, open **Actions → Build OpenWrt APKs → Run workflow**. Set the SDK architecture and release to match a supported official SDK container. The result contains both APKs, `install.sh`, `PACKAGES`, `SHA256SUMS`, the English and Persian guides, the license and attribution files, and `SOURCE_COMMIT` identifying the exact source revision. CI artifacts are development packages and are not signed by a key trusted by a stock router; verify their checksums and use `--allow-untrusted` only when you trust the repository and workflow run.
 
 Tag pushes run the same read-only build but deliberately do not create a GitHub Release. After the APKs pass the lab-router checklist, create the Release manually and attach the validated artifact files. This keeps pull-request builds and release publishing under separate permissions.
 

--- a/ci/validate_release.py
+++ b/ci/validate_release.py
@@ -60,8 +60,10 @@ REQUIRED_PATHS = (
     "ci/test-init-enable.sh",
     "docs/RELEASE_TESTING.md",
     "scripts/validate-release.sh",
+    "install.sh",
     "tests/fakes/openwrt_cmd.py",
     "tests/test_certificates.py",
+    "tests/test_installer.py",
     "tests/test_passwall2.py",
     "xray-mitm/Makefile",
     "luci-app-xray-mitm/Makefile",
@@ -357,6 +359,8 @@ def check_workflow(root: Path, errors: list[str]) -> None:
         if not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action):
             errors.append(f"{relative} action is not pinned to a full commit: {action}")
     for required in (
+        "install.sh",
+        "PACKAGES",
         "SHA256SUMS",
         "LICENSE",
         "README.md",

--- a/docs/RELEASE_TESTING.md
+++ b/docs/RELEASE_TESTING.md
@@ -1,6 +1,6 @@
 # Release testing
 
-The offline validator is the first release gate. It checks the expected two-package layout; parses JSON files including `config.json.example`; verifies the fixed localhost listeners, certificate paths, disabled first-run state, exact core and LuCI dependency tokens, narrow ACL split, noarch declarations, and pinned workflow actions; and rejects common router exports, package binaries, certificate/key files, and private-key PEM content. The wrapper also runs isolated certificate lifecycle tests with real OpenSSL (generation, permissions, public-only export, matching import, and mismatched-key rejection), a PassWall2 transaction fixture (preview, apply, exact rollback, pending-change refusal, privacy, and interrupted recovery), exercises the disabled-versus-explicit init enable behavior in temporary storage, parses every installed shell script, and checks the LuCI JavaScript syntax when Node.js is available.
+The offline validator is the first release gate. It checks the expected two-package layout; parses JSON files including `config.json.example`; verifies the fixed localhost listeners, certificate paths, disabled first-run state, exact core and LuCI dependency tokens, narrow ACL split, noarch declarations, and pinned workflow actions; and rejects common router exports, package binaries, certificate/key files, and private-key PEM content. The wrapper also runs isolated certificate lifecycle tests with real OpenSSL (generation, permissions, public-only export, matching import, and mismatched-key rejection), a PassWall2 transaction fixture (preview, apply, exact rollback, pending-change refusal, privacy, and interrupted recovery), installer tests (root requirement, verified download, and stop-before-install on checksum failure), exercises the disabled-versus-explicit init enable behavior in temporary storage, parses every installed shell script, and checks the LuCI JavaScript syntax when Node.js is available.
 
 **MAC:**
 
@@ -11,20 +11,21 @@ sh scripts/validate-release.sh
 
 The structural checks use only Python's standard library and the shell checks use the host's `/bin/sh`. Node.js is optional locally and present on the GitHub-hosted runner. The validation does not connect to a router, alter network settings, or need internet access.
 
-GitHub Actions runs the same test before starting the OpenWrt SDK build. A successful SDK job must produce exactly one `xray-mitm` APK, one `luci-app-xray-mitm` APK, `SHA256SUMS`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, the English and Persian README files, and a `SOURCE_COMMIT` file.
+GitHub Actions runs the same test before starting the OpenWrt SDK build. A successful SDK job must produce exactly one `xray-mitm` APK, one `luci-app-xray-mitm` APK, `install.sh`, `PACKAGES`, `SHA256SUMS`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, the English and Persian README files, and a `SOURCE_COMMIT` file.
 
 Before publishing a tagged build, also perform a disposable-router or lab-router test:
 
 1. Confirm the firmware reports OpenWrt 25.12.5 or later and uses APK.
-2. Confirm installation leaves the service stopped, both the UCI master and `boot_enabled` switches at zero, and no `S98xray-mitm` or `K10xray-mitm` boot links; also confirm it does not change PassWall2, firewall, DNS, or routing.
-3. Generate a candidate CA, download the public certificate, and confirm no private-key download exists.
-4. Confirm the private key on the router is owned by `root` and has mode `0600`.
-5. Activate the candidate, start the service, and run the built-in health check.
-6. Preview PassWall2 changes and compare the preview with a fresh UCI backup before applying.
-7. Exercise rollback and confirm the original rule order and node assignments return exactly.
-8. Confirm listeners remain bound only to `127.0.0.1`.
-9. Verify a selected MITM domain shows the local CA issuer while an unrelated control domain shows its normal public issuer.
-10. Confirm the root-only PassWall2 rollback snapshot is not exposed through LuCI and remember that it can contain node credentials.
-11. Inspect the final Git diff and release archive again for secrets.
+2. Run the one-command installer against the candidate release and confirm it verifies both checksums before invoking APK.
+3. Confirm installation leaves the service stopped, both the UCI master and `boot_enabled` switches at zero, and no `S98xray-mitm` or `K10xray-mitm` boot links; also confirm it does not change PassWall2, firewall, DNS, or routing.
+4. Generate a candidate CA, download the public certificate, and confirm no private-key download exists.
+5. Confirm the private key on the router is owned by `root` and has mode `0600`.
+6. Activate the candidate, start the service, and run the built-in health check.
+7. Preview PassWall2 changes and compare the preview with a fresh UCI backup before applying.
+8. Exercise rollback and confirm the original rule order and node assignments return exactly.
+9. Confirm listeners remain bound only to `127.0.0.1`.
+10. Verify a selected MITM domain shows the local CA issuer while an unrelated control domain shows its normal public issuer.
+11. Confirm the root-only PassWall2 rollback snapshot is not exposed through LuCI and remember that it can contain node credentials.
+12. Inspect the final Git diff and release archive again for secrets.
 
 Do not use a production router as the first test of a new release.

--- a/install.sh
+++ b/install.sh
@@ -97,9 +97,11 @@ cd "$work_dir"
 if download "$base_url/PACKAGES" PACKAGES 2>/dev/null; then
 	core_asset="$(sed -n '/^xray-mitm-[A-Za-z0-9._~+-]*\.apk$/p' PACKAGES)"
 	luci_asset="$(sed -n '/^luci-app-xray-mitm-[A-Za-z0-9._~+-]*\.apk$/p' PACKAGES)"
-	[ "$(printf '%s\n' "$core_asset" | wc -l | tr -d ' ')" = '1' ] || \
+	[ -n "$core_asset" ] && \
+		[ "$(printf '%s\n' "$core_asset" | wc -l | tr -d ' ')" = '1' ] || \
 		die 'The release package list does not identify exactly one core APK.'
-	[ "$(printf '%s\n' "$luci_asset" | wc -l | tr -d ' ')" = '1' ] || \
+	[ -n "$luci_asset" ] && \
+		[ "$(printf '%s\n' "$luci_asset" | wc -l | tr -d ' ')" = '1' ] || \
 		die 'The release package list does not identify exactly one LuCI APK.'
 else
 	# v0.1.0 predates PACKAGES. Keep this fallback so the installer can install it.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+set -eu
+
+PROJECT='duuuude/xray-mitm-openwrt'
+FALLBACK_CORE_ASSET='xray-mitm-0.1.0-r4.apk'
+FALLBACK_LUCI_ASSET='luci-app-xray-mitm-26.249.69617~5f96cdb.apk'
+RELEASE="${XRAY_MITM_RELEASE:-latest}"
+RELEASE_FILE="${XRAY_MITM_OPENWRT_RELEASE_FILE:-/etc/openwrt_release}"
+
+say() {
+	printf '%s\n' "$*"
+}
+
+die() {
+	printf 'ERROR: %s\n' "$*" >&2
+	exit 1
+}
+
+download() {
+	url="$1"
+	destination="$2"
+
+	if command -v uclient-fetch >/dev/null 2>&1; then
+		uclient-fetch -q -O "$destination" "$url"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -q -O "$destination" "$url"
+	elif command -v curl >/dev/null 2>&1; then
+		curl -fL --retry 3 -o "$destination" "$url"
+	else
+		die 'No supported HTTPS downloader was found (uclient-fetch, wget, or curl).'
+	fi
+}
+
+cleanup() {
+	if [ -n "${work_dir:-}" ] && [ -d "$work_dir" ]; then
+		rm -rf "$work_dir"
+	fi
+}
+
+supported_openwrt_release() {
+	version="${DISTRIB_RELEASE%%-*}"
+	old_ifs="$IFS"
+	IFS='.'
+	set -- $version
+	IFS="$old_ifs"
+	major="${1:-0}"
+	minor="${2:-0}"
+	patch="${3:-0}"
+
+	case "$major:$minor:$patch" in
+		*[!0-9:]*) return 1 ;;
+	esac
+
+	[ "$major" -gt 25 ] ||
+		{ [ "$major" -eq 25 ] && [ "$minor" -gt 12 ]; } ||
+		{ [ "$major" -eq 25 ] && [ "$minor" -eq 12 ] && [ "$patch" -ge 5 ]; }
+}
+
+[ "$(id -u)" = '0' ] || die 'Run this installer as root on the OpenWrt router.'
+[ -r "$RELEASE_FILE" ] || die 'This does not appear to be an OpenWrt router.'
+
+# shellcheck disable=SC1090
+. "$RELEASE_FILE"
+[ -n "${DISTRIB_RELEASE:-}" ] || die 'OpenWrt release information is incomplete.'
+command -v apk >/dev/null 2>&1 || die 'This release requires an APK-based OpenWrt installation (25.12.5 or later).'
+command -v sha256sum >/dev/null 2>&1 || die 'sha256sum is required to verify the downloaded packages.'
+supported_openwrt_release || die "OpenWrt $DISTRIB_RELEASE is unsupported; version 25.12.5 or later is required."
+
+case "$RELEASE" in
+	latest)
+		base_url="https://github.com/$PROJECT/releases/latest/download"
+		;;
+	v[0-9]*.[0-9]*.[0-9]*)
+		case "$RELEASE" in
+			*[!A-Za-z0-9._-]*) die "Invalid release name: $RELEASE" ;;
+		esac
+		base_url="https://github.com/$PROJECT/releases/download/$RELEASE"
+		;;
+	*)
+		die "Invalid release name: $RELEASE"
+		;;
+esac
+
+if [ -n "${XRAY_MITM_BASE_URL:-}" ]; then
+	base_url="${XRAY_MITM_BASE_URL%/}"
+fi
+
+umask 077
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/xray-mitm-install.XXXXXX")"
+trap cleanup EXIT HUP INT TERM
+
+say "OpenWrt: $DISTRIB_RELEASE"
+say "Release: $RELEASE"
+say 'Downloading release files...'
+
+cd "$work_dir"
+if download "$base_url/PACKAGES" PACKAGES 2>/dev/null; then
+	core_asset="$(sed -n '/^xray-mitm-[A-Za-z0-9._~+-]*\.apk$/p' PACKAGES)"
+	luci_asset="$(sed -n '/^luci-app-xray-mitm-[A-Za-z0-9._~+-]*\.apk$/p' PACKAGES)"
+	[ "$(printf '%s\n' "$core_asset" | wc -l | tr -d ' ')" = '1' ] || \
+		die 'The release package list does not identify exactly one core APK.'
+	[ "$(printf '%s\n' "$luci_asset" | wc -l | tr -d ' ')" = '1' ] || \
+		die 'The release package list does not identify exactly one LuCI APK.'
+else
+	# v0.1.0 predates PACKAGES. Keep this fallback so the installer can install it.
+	core_asset="$FALLBACK_CORE_ASSET"
+	luci_asset="$FALLBACK_LUCI_ASSET"
+fi
+
+download "$base_url/SHA256SUMS" SHA256SUMS
+download "$base_url/$core_asset" "$core_asset"
+download "$base_url/$luci_asset" "$luci_asset"
+
+awk -v core="$core_asset" -v luci="$luci_asset" \
+	'$2 == core || $2 == luci { print }' SHA256SUMS > packages.sha256
+[ "$(wc -l < packages.sha256 | tr -d ' ')" = '2' ] || \
+	die 'The release checksum file does not contain both expected APKs.'
+
+say 'Verifying SHA-256 checksums...'
+sha256sum -c packages.sha256
+
+if [ "${XRAY_MITM_SKIP_BACKUP:-0}" != '1' ] && \
+	{ [ -e /etc/config/xray-mitm ] || [ -d /etc/xray-mitm ]; }
+then
+	backup_file="/root/xray-mitm-before-install-$(date +%Y%m%d-%H%M%S).tar.gz"
+	set --
+	[ ! -e /etc/config/xray-mitm ] || set -- "$@" /etc/config/xray-mitm
+	[ ! -d /etc/xray-mitm ] || set -- "$@" /etc/xray-mitm
+	tar -czf "$backup_file" "$@"
+	chmod 0600 "$backup_file"
+	say "Protected configuration backup: $backup_file"
+fi
+
+say 'Refreshing package metadata...'
+apk update
+
+say 'Installing xray-mitm and its LuCI page...'
+apk add --allow-untrusted "./$core_asset" "./$luci_asset"
+
+say ''
+say 'Installation complete.'
+say 'Open LuCI over HTTPS, then go to Services -> MITM Domain Fronting.'
+say 'Install the packaged default configuration, create and activate a CA, then start the service.'
+say 'Install only mycert.crt on client devices. Keep mycert.key on the router and in protected backups.'
+say 'PassWall2 routing remains unchanged until you preview and apply it in LuCI.'

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -7,6 +7,7 @@ project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/ci/validate_release.py" "$project_dir"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_passwall2.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_certificates.py"
+PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_installer.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_startup.py"
 
 for relative in \
@@ -18,6 +19,7 @@ for relative in \
 	xray-mitm/files/usr/libexec/xray-mitm/config \
 	xray-mitm/files/usr/libexec/xray-mitm/passwall2 \
 	xray-mitm/files/usr/sbin/xray-mitmctl \
+	install.sh \
 	ci/test-init-enable.sh
 do
 	sh -n "$project_dir/$relative"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Behavior checks for the release installer without network or router access."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+CORE_ASSET = "xray-mitm-0.1.0-r4.apk"
+LUCI_ASSET = "luci-app-xray-mitm-26.249.69617~5f96cdb.apk"
+
+
+class InstallerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin_dir = self.root / "bin"
+        self.fixtures = self.root / "fixtures"
+        self.bin_dir.mkdir()
+        self.fixtures.mkdir()
+        self.apk_log = self.root / "apk.log"
+        self.release_file = self.root / "openwrt_release"
+        self.release_file.write_text("DISTRIB_RELEASE='25.12.5'\n", encoding="utf-8")
+
+        (self.fixtures / CORE_ASSET).write_bytes(b"core package\n")
+        (self.fixtures / LUCI_ASSET).write_bytes(b"luci package\n")
+        self.write_manifest()
+
+        self.write_fake(
+            "id",
+            """
+            import os
+            print(os.environ.get("FAKE_UID", "0"))
+            """,
+        )
+        self.write_fake(
+            "uclient-fetch",
+            """
+            import os
+            import shutil
+            import sys
+            from pathlib import Path
+
+            destination = Path(sys.argv[sys.argv.index("-O") + 1])
+            asset = sys.argv[-1].rsplit("/", 1)[-1]
+            shutil.copyfile(Path(os.environ["XRAY_MITM_FIXTURES"]) / asset, destination)
+            """,
+        )
+        self.write_fake(
+            "sha256sum",
+            """
+            import hashlib
+            import sys
+            from pathlib import Path
+
+            if len(sys.argv) != 3 or sys.argv[1] != "-c":
+                raise SystemExit(2)
+            ok = True
+            for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines():
+                expected, name = line.split(None, 1)
+                actual = hashlib.sha256(Path(name).read_bytes()).hexdigest()
+                if actual == expected:
+                    print(f"{name}: OK")
+                else:
+                    print(f"{name}: FAILED", file=sys.stderr)
+                    ok = False
+            raise SystemExit(0 if ok else 1)
+            """,
+        )
+        self.write_fake(
+            "apk",
+            """
+            import json
+            import os
+            import sys
+            from pathlib import Path
+
+            with Path(os.environ["XRAY_MITM_APK_LOG"]).open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(sys.argv[1:]) + "\\n")
+            """,
+        )
+
+    def write_fake(self, name: str, body: str) -> None:
+        path = self.bin_dir / name
+        path.write_text(
+            "#!/usr/bin/env python3\n" + textwrap.dedent(body).lstrip(),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+
+    def write_manifest(self, core_hash: str | None = None) -> None:
+        entries = []
+        for name in (LUCI_ASSET, CORE_ASSET):
+            digest = hashlib.sha256((self.fixtures / name).read_bytes()).hexdigest()
+            if name == CORE_ASSET and core_hash is not None:
+                digest = core_hash
+            entries.append(f"{digest}  {name}\n")
+        (self.fixtures / "SHA256SUMS").write_text("".join(entries), encoding="utf-8")
+
+    def run_installer(self, *, fake_uid: str = "0") -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_UID": fake_uid,
+                "PATH": f"{self.bin_dir}:{env['PATH']}",
+                "XRAY_MITM_APK_LOG": str(self.apk_log),
+                "XRAY_MITM_BASE_URL": "https://fixtures.invalid/release",
+                "XRAY_MITM_FIXTURES": str(self.fixtures),
+                "XRAY_MITM_OPENWRT_RELEASE_FILE": str(self.release_file),
+            }
+        )
+        return subprocess.run(
+            ["sh", str(INSTALLER)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=False,
+        )
+
+    def apk_calls(self) -> list[list[str]]:
+        if not self.apk_log.exists():
+            return []
+        return [json.loads(line) for line in self.apk_log.read_text().splitlines()]
+
+    def test_downloads_verifies_and_installs_both_packages(self) -> None:
+        result = self.run_installer()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Installation complete.", result.stdout)
+        self.assertEqual(
+            self.apk_calls(),
+            [
+                ["update"],
+                ["add", "--allow-untrusted", f"./{CORE_ASSET}", f"./{LUCI_ASSET}"],
+            ],
+        )
+
+    def test_checksum_failure_stops_before_apk_changes(self) -> None:
+        self.write_manifest(core_hash="0" * 64)
+
+        result = self.run_installer()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("FAILED", result.stderr)
+        self.assertEqual(self.apk_calls(), [])
+
+    def test_package_list_selects_names_for_a_future_release(self) -> None:
+        core = "xray-mitm-0.2.0-r1.apk"
+        luci = "luci-app-xray-mitm-0.2.0-r1.apk"
+        (self.fixtures / core).write_bytes(b"future core package\n")
+        (self.fixtures / luci).write_bytes(b"future luci package\n")
+        (self.fixtures / "PACKAGES").write_text(f"{luci}\n{core}\n", encoding="utf-8")
+        entries = []
+        for name in (luci, core):
+            digest = hashlib.sha256((self.fixtures / name).read_bytes()).hexdigest()
+            entries.append(f"{digest}  {name}\n")
+        (self.fixtures / "SHA256SUMS").write_text("".join(entries), encoding="utf-8")
+
+        result = self.run_installer()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            self.apk_calls(),
+            [
+                ["update"],
+                ["add", "--allow-untrusted", f"./{core}", f"./{luci}"],
+            ],
+        )
+
+    def test_requires_root(self) -> None:
+        result = self.run_installer(fake_uid="1000")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Run this installer as root", result.stderr)
+        self.assertEqual(self.apk_calls(), [])
+
+    def test_rejects_an_older_openwrt_release(self) -> None:
+        self.release_file.write_text("DISTRIB_RELEASE='25.12.4'\n", encoding="utf-8")
+
+        result = self.run_installer()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("25.12.5 or later is required", result.stderr)
+        self.assertEqual(self.apk_calls(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -178,6 +178,15 @@ class InstallerTests(unittest.TestCase):
             ],
         )
 
+    def test_incomplete_package_list_stops_before_download_or_install(self) -> None:
+        (self.fixtures / "PACKAGES").write_text(f"{LUCI_ASSET}\n", encoding="utf-8")
+
+        result = self.run_installer()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not identify exactly one core APK", result.stderr)
+        self.assertEqual(self.apk_calls(), [])
+
     def test_requires_root(self) -> None:
         result = self.run_installer(fake_uid="1000")
 


### PR DESCRIPTION
New users currently have to open a workflow artifact or release, download three files, copy them to the router, verify them, and install both packages manually. This change adds a single macOS, Windows PowerShell, or router command that performs the download and package installation for supported APK-based OpenWrt routers.

The installer:

- requires root on OpenWrt 25.12.5 or later with APK;
- downloads package names from the release `PACKAGES` manifest, with a compatibility fallback for v0.1.0;
- verifies both APKs against `SHA256SUMS` before running any APK command;
- creates a root-only configuration and CA backup during upgrades;
- installs the core and LuCI packages without generating a CA, starting the service, or changing PassWall2 routing;
- is included in future workflow artifacts with the generated package manifest.

The English and Persian quick-start sections now lead with the one-command path and keep the manual Mac and Windows procedure as a fallback.

Validation: `sh scripts/validate-release.sh` passes, including six offline installer tests covering the success path, future package-name discovery, incomplete manifests, checksum failure, non-root execution, and unsupported OpenWrt versions.
