### PR TITLE
Publish checksum-pinned public installer

### DIFF
--- a/.github/workflows/publish-feed.yml
+++ b/.github/workflows/publish-feed.yml
@@ -78,6 +78,16 @@ jobs:
           feed_dir="site/feed/$OPENWRT_SERIES/all"
           mkdir -p "$feed_dir"
 
+          cp install.sh site/install.sh
+          chmod 0755 site/install.sh
+          printf '%s  %s\n' \
+            'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' \
+            'install.sh' > site/INSTALLER_SHA256
+          (
+            cd site
+            sha256sum -c INSTALLER_SHA256
+          )
+
           mapfile -t core_apks < <(find bin -type f -name 'xray-mitm-*.apk')
           mapfile -t luci_apks < <(find bin -type f -name 'luci-app-xray-mitm-*.apk')
           mapfile -t indexes < <(find bin -type f -path "*/$FEED_NAME/packages.adb")
@@ -137,6 +147,8 @@ jobs:
             "$feed_dir/SOURCE_COMMIT"
             "signed-site/feed/xray-mitm-feed-v1.pem"
             "signed-site/feed/PUBLIC_KEY_SHA256"
+            "signed-site/install.sh"
+            "signed-site/INSTALLER_SHA256"
           )
 
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
@@ -144,7 +156,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --title "xray-mitm $GITHUB_REF_NAME" \
-              --notes "Authenticated OpenWrt APK feed release. Install or update with the repository install.sh; APK verifies the signed feed and packages."
+              --notes "Authenticated OpenWrt APK feed release. Install or update with the checksum-pinned public installer at https://duuuude.github.io/xray-mitm-openwrt/install.sh; APK verifies the signed feed and packages."
           fi
           gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" --clobber

--- a/README.fa.md
+++ b/README.fa.md
@@ -18,13 +18,13 @@ feed عمومی فعلی برای OpenWrt رسمی **نسخه 25.12.5 و نسخ�
 **MAC:**
 
 ```sh
-ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh'
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 **WINDOWS PC (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1 "wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh"
+ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 اگر از قبل با SSH داخل روتر هستید:
@@ -32,8 +32,10 @@ ssh.exe root@192.168.1.1 "wget -qO /tmp/install-xray-mitm.sh https://raw.githubu
 **ROUTER:**
 
 ```sh
-wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh
+wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' 'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
+
+دستور، فایل نصب‌کننده عمومی را پیش از اجرا بررسی می‌کند. SHA-256 ثابت آن `bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d` است.
 
 همین دستور هم نصب اولیه و هم به‌روزرسانی‌های بعدی را انجام می‌دهد. نصب‌کننده:
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Replace `192.168.1.1` if your router uses another address. Enter the router pass
 **MAC:**
 
 ```sh
-ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh'
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 **WINDOWS PC (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1 "wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh"
+ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 If you are already connected through SSH:
@@ -32,8 +32,10 @@ If you are already connected through SSH:
 **ROUTER:**
 
 ```sh
-wget -qO /tmp/install-xray-mitm.sh https://raw.githubusercontent.com/duuuude/xray-mitm-openwrt/main/install.sh && sh /tmp/install-xray-mitm.sh
+wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' 'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
+
+The command verifies the public installer before running it. Its pinned SHA-256 is `bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d`.
 
 The same command handles first installation and later updates. It:
 

--- a/tests/test_signed_feed.py
+++ b/tests/test_signed_feed.py
@@ -15,6 +15,7 @@ WORKFLOW = ROOT / ".github/workflows/publish-feed.yml"
 PUBLIC_KEY = ROOT / "keys/xray-mitm-feed-v1.pem"
 VERSION_CHECK = ROOT / "scripts/check-release-version.sh"
 EXPECTED_KEY_SHA256 = "3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a"
+EXPECTED_INSTALLER_SHA256 = "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d"
 
 
 class SignedFeedTests(unittest.TestCase):
@@ -41,6 +42,26 @@ class SignedFeedTests(unittest.TestCase):
         self.assertIn('INDEX: "1"', text)
         self.assertIn("actions/deploy-pages@", text)
         self.assertNotIn("--allow-untrusted", text)
+
+    def test_public_bootstrap_is_published_and_checksum_pinned(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        installer_digest = subprocess.check_output(
+            ["sha256sum", str(INSTALLER)], text=True
+        ).split()[0]
+
+        self.assertEqual(installer_digest, EXPECTED_INSTALLER_SHA256)
+        self.assertIn("cp install.sh site/install.sh", workflow)
+        self.assertIn("site/INSTALLER_SHA256", workflow)
+        self.assertIn('"signed-site/install.sh"', workflow)
+        self.assertIn('"signed-site/INSTALLER_SHA256"', workflow)
+
+        for readme in (ROOT / "README.md", ROOT / "README.fa.md"):
+            text = readme.read_text(encoding="utf-8")
+            self.assertNotIn("raw.githubusercontent.com", text)
+            self.assertIn(
+                "https://duuuude.github.io/xray-mitm-openwrt/install.sh", text
+            )
+            self.assertEqual(text.count(EXPECTED_INSTALLER_SHA256), 4)
 
     def test_installer_uses_native_signed_repository_only(self) -> None:
         text = INSTALLER.read_text(encoding="utf-8")


### PR DESCRIPTION
The repository is private, so the previous one-command setup could not download `install.sh` anonymously from `raw.githubusercontent.com`. This publishes the installer through the public Pages site and pins its SHA-256 in the Mac, Windows, and router commands before execution.

The signed-release workflow now verifies and publishes `install.sh` plus `INSTALLER_SHA256` to Pages and the GitHub Release. The full release validation suite passes, including a new regression test for public bootstrap availability and checksum pinning.
