### PR TITLE
Fix Release checksum filenames

### DIFF
--- a/.github/workflows/publish-feed.yml
+++ b/.github/workflows/publish-feed.yml
@@ -140,15 +140,36 @@ jobs:
         run: |
           set -euo pipefail
           feed_dir="signed-site/feed/$OPENWRT_SERIES/all"
+          release_dir="release-assets"
+          mkdir -p "$release_dir"
+
+          # GitHub normalizes '~' in uploaded asset names to '.', so prepare the
+          # final names first and generate a checksum manifest that matches what
+          # users actually download from the Release.
+          for apk in "$feed_dir"/*.apk; do
+            apk_name="$(basename "$apk")"
+            release_name="${apk_name//\~/.}"
+            cp "$apk" "$release_dir/$release_name"
+          done
+          cp "$feed_dir/packages.adb" "$release_dir/packages.adb"
+          cp "$feed_dir/SOURCE_COMMIT" "$release_dir/SOURCE_COMMIT"
+          cp "signed-site/feed/xray-mitm-feed-v1.pem" \
+            "$release_dir/xray-mitm-feed-v1.pem"
+          cp "signed-site/feed/PUBLIC_KEY_SHA256" \
+            "$release_dir/PUBLIC_KEY_SHA256"
+          cp "signed-site/install.sh" "$release_dir/install.sh"
+          cp "signed-site/INSTALLER_SHA256" "$release_dir/INSTALLER_SHA256"
+          (
+            cd "$release_dir"
+            sha256sum ./*.apk packages.adb install.sh \
+              xray-mitm-feed-v1.pem > SHA256SUMS
+            sha256sum -c SHA256SUMS
+            sha256sum -c INSTALLER_SHA256
+            sha256sum -c PUBLIC_KEY_SHA256
+          )
+
           assets=(
-            "$feed_dir"/*.apk
-            "$feed_dir/packages.adb"
-            "$feed_dir/SHA256SUMS"
-            "$feed_dir/SOURCE_COMMIT"
-            "signed-site/feed/xray-mitm-feed-v1.pem"
-            "signed-site/feed/PUBLIC_KEY_SHA256"
-            "signed-site/install.sh"
-            "signed-site/INSTALLER_SHA256"
+            "$release_dir"/*
           )
 
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then

--- a/tests/test_signed_feed.py
+++ b/tests/test_signed_feed.py
@@ -63,6 +63,15 @@ class SignedFeedTests(unittest.TestCase):
             )
             self.assertEqual(text.count(EXPECTED_INSTALLER_SHA256), 4)
 
+    def test_release_checksums_use_final_github_asset_names(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('release_name="${apk_name//\\~/.}"', workflow)
+        self.assertIn('cd "$release_dir"', workflow)
+        self.assertIn("sha256sum ./*.apk packages.adb install.sh", workflow)
+        self.assertIn('"$release_dir"/*', workflow)
+        self.assertNotIn('"$feed_dir/SHA256SUMS"', workflow)
+
     def test_installer_uses_native_signed_repository_only(self) -> None:
         text = INSTALLER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
GitHub normalizes the LuCI APK Release filename from `~` to `.`, so the published `SHA256SUMS` named a file users could not download.

This change prepares the final Release filenames before upload, generates and verifies a Release-specific checksum manifest, and adds a regression test. The signed Pages feed keeps its native package filename and index unchanged.

Validation:
- `sh scripts/validate-release.sh`
- workflow YAML parse
- `git diff --check`
