### PR TITLE
Make authenticated installer upgrade existing packages

### DIFF
--- a/.github/workflows/publish-feed.yml
+++ b/.github/workflows/publish-feed.yml
@@ -81,7 +81,7 @@ jobs:
           cp install.sh site/install.sh
           chmod 0755 site/install.sh
           printf '%s  %s\n' \
-            'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' \
+            '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' \
             'install.sh' > site/INSTALLER_SHA256
           (
             cd site

--- a/README.fa.md
+++ b/README.fa.md
@@ -18,13 +18,13 @@ feed عمومی فعلی برای OpenWrt رسمی **نسخه 25.12.5 و نسخ�
 **MAC:**
 
 ```sh
-ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 **WINDOWS PC (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
+ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 اگر از قبل با SSH داخل روتر هستید:
@@ -32,10 +32,10 @@ ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.git
 **ROUTER:**
 
 ```sh
-wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' 'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
+wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-دستور، فایل نصب‌کننده عمومی را پیش از اجرا بررسی می‌کند. SHA-256 ثابت آن `bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d` است.
+دستور، فایل نصب‌کننده عمومی را پیش از اجرا بررسی می‌کند. SHA-256 ثابت آن `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405` است.
 
 همین دستور هم نصب اولیه و هم به‌روزرسانی‌های بعدی را انجام می‌دهد. نصب‌کننده:
 
@@ -150,10 +150,10 @@ issuer: CN=MITM-DomainFronting
 
 ```sh
 apk update
-apk add xray-mitm luci-app-xray-mitm
+apk upgrade xray-mitm luci-app-xray-mitm
 ```
 
-این دستور فقط همین دو بسته انتخاب‌شده و وابستگی‌های لازم آن‌ها را بررسی می‌کند. از `apk upgrade` بدون برنامه به‌عنوان جایگزین ارتقای firmware استفاده نکنید.
+این دستور فقط همین دو بسته انتخاب‌شده و وابستگی‌های لازم آن‌ها را ارتقا می‌دهد. از اجرای `apk upgrade` بدون نام بسته‌ها به‌عنوان جایگزین ارتقای firmware استفاده نکنید.
 
 به‌روزرسانی، `/etc/config/xray-mitm`، پوشه `/etc/xray-mitm/`، CA فعال، وضعیت سرویس و تنظیمات PassWall2 را حفظ می‌کند. قبل از تغییر feed یا بسته‌ها، نصب‌کننده فایل پشتیبان `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` را با سطح دسترسی `0600` می‌سازد.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Replace `192.168.1.1` if your router uses another address. Enter the router pass
 **MAC:**
 
 ```sh
-ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
+ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 **WINDOWS PC (PowerShell):**
 
 ```powershell
-ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
+ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
 If you are already connected through SSH:
@@ -32,10 +32,10 @@ If you are already connected through SSH:
 **ROUTER:**
 
 ```sh
-wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' 'bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
+wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-The command verifies the public installer before running it. Its pinned SHA-256 is `bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d`.
+The command verifies the public installer before running it. Its pinned SHA-256 is `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
 
 The same command handles first installation and later updates. It:
 
@@ -150,10 +150,10 @@ The easiest update is to run the same one-command installer again. After the fee
 
 ```sh
 apk update
-apk add xray-mitm luci-app-xray-mitm
+apk upgrade xray-mitm luci-app-xray-mitm
 ```
 
-This asks APK to solve and update these two explicitly selected packages and required dependencies. Do not use a blind `apk upgrade` as a replacement for a planned OpenWrt firmware upgrade.
+This upgrades only these two explicitly selected packages and required dependencies. Do not use an unrestricted `apk upgrade` as a replacement for a planned OpenWrt firmware upgrade.
 
 Updates preserve `/etc/config/xray-mitm`, `/etc/xray-mitm/`, the active CA, service settings, and existing PassWall2 configuration. The installer creates `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` with mode `0600` before changing feed or package state.
 

--- a/ci/validate_release.py
+++ b/ci/validate_release.py
@@ -442,12 +442,16 @@ def check_signed_feed(root: Path, errors: list[str]) -> None:
         "/etc/apk/keys",
         "/etc/apk/repositories.d",
         "apk add xray-mitm luci-app-xray-mitm",
+        "apk upgrade xray-mitm luci-app-xray-mitm",
     ):
         if required not in installer:
             errors.append(f"{installer_relative} signed-feed logic is missing {required}")
     if re.search(r"apk[ \t]+(?:add|upgrade).*--allow-untrusted", installer):
         errors.append(f"{installer_relative} must not bypass APK signature verification")
-    if re.search(r"apk[ \t]+upgrade", installer):
+    targeted_installer = installer.replace(
+        "apk upgrade xray-mitm luci-app-xray-mitm", ""
+    )
+    if re.search(r"apk[ \t]+upgrade", targeted_installer):
         errors.append(f"{installer_relative} must not upgrade unrelated router packages")
 
 

--- a/docs/SIGNED_FEED.md
+++ b/docs/SIGNED_FEED.md
@@ -50,9 +50,9 @@ The workflow derives a public key from the secret and compares it with the commi
 git switch main
 git pull --ff-only
 sh scripts/validate-release.sh
-git tag -s v0.2.1 -m 'xray-mitm v0.2.1'
-git tag -v v0.2.1
-git push origin v0.2.1
+git tag -s v0.2.2 -m 'xray-mitm v0.2.2'
+git tag -v v0.2.2
+git push origin v0.2.2
 ```
 
 **WINDOWS PC (PowerShell with Git and a configured signing key):**
@@ -61,12 +61,12 @@ git push origin v0.2.1
 git switch main
 git pull --ff-only
 wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
-git tag -s v0.2.1 -m "xray-mitm v0.2.1"
-git tag -v v0.2.1
-git push origin v0.2.1
+git tag -s v0.2.2 -m "xray-mitm v0.2.2"
+git tag -v v0.2.2
+git push origin v0.2.2
 ```
 
-Replace `v0.2.1` with the reviewed version. The workflow rejects a mismatched tag or package release other than `r1`.
+Replace `v0.2.2` with the reviewed version. The workflow rejects a mismatched tag or package release other than `r1`.
 
 ## Verify the published key
 
@@ -98,7 +98,7 @@ The live feed contains the current supported version. Every signed version is al
 
 ```sh
 apk update
-apk add xray-mitm luci-app-xray-mitm
+apk upgrade xray-mitm luci-app-xray-mitm
 ```
 
 For rollback, download both APKs from one older signed release, verify its checksums, and install both together. Test configuration compatibility before crossing a schema change. Never use unrestricted `apk upgrade` as the project updater.

--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,18 @@ if ! apk add xray-mitm luci-app-xray-mitm; then
 	fi
 	die 'Package installation failed and automatic rollback was incomplete; use the protected backup.'
 fi
+
+# OpenWrt apk v3's add operation records missing packages in world, but it does
+# not upgrade an already installed package merely because a newer candidate is
+# available. Run a targeted upgrade so repeat invocations update these two
+# packages without performing an unsafe system-wide upgrade.
+if ! apk upgrade xray-mitm luci-app-xray-mitm; then
+	if restore_feed_state; then
+		feed_state_changed=0
+		die 'Package upgrade failed; the previous feed and package-selection state was restored.'
+	fi
+	die 'Package upgrade failed and automatic rollback was incomplete; use the protected backup.'
+fi
 feed_state_changed=0
 
 if [ -r "$APK_WORLD" ]; then

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -94,6 +94,8 @@ class InstallerTests(unittest.TestCase):
                 raise SystemExit(1)
             if args[:1] == ["add"] and os.environ.get("FAKE_APK_ADD_FAIL") == "1":
                 raise SystemExit(1)
+            if args[:1] == ["upgrade"] and os.environ.get("FAKE_APK_UPGRADE_FAIL") == "1":
+                raise SystemExit(1)
             if args == ["add", "xray-mitm", "luci-app-xray-mitm"]:
                 world = Path(os.environ["XRAY_MITM_APK_WORLD"])
                 lines = [
@@ -177,7 +179,11 @@ class InstallerTests(unittest.TestCase):
         self.assertIn(self.public_key_sha256, result.stdout)
         self.assertEqual(
             self.apk_calls(),
-            [["update"], ["add", "xray-mitm", "luci-app-xray-mitm"]],
+            [
+                ["update"],
+                ["add", "xray-mitm", "luci-app-xray-mitm"],
+                ["upgrade", "xray-mitm", "luci-app-xray-mitm"],
+            ],
         )
         self.assertEqual(self.installed_key.read_bytes(), self.public_key.read_bytes())
         self.assertEqual(self.repository_file.read_text(), FEED_URL + "\n")
@@ -243,6 +249,27 @@ class InstallerTests(unittest.TestCase):
         self.assertEqual(
             self.apk_calls(),
             [["update"], ["add", "xray-mitm", "luci-app-xray-mitm"]],
+        )
+        self.assertFalse(self.installed_key.exists())
+        self.assertFalse(self.repository_file.exists())
+        self.assertFalse(self.keep_file.exists())
+        self.assertEqual(self.world_file.read_text(), previous_world)
+
+    def test_targeted_upgrade_failure_restores_previous_feed_and_world(self) -> None:
+        previous_world = "base-files\nxray-mitm=0.1.0-r4\n"
+        self.world_file.write_text(previous_world, encoding="utf-8")
+
+        result = self.run_installer(extra_env={"FAKE_APK_UPGRADE_FAIL": "1"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Package upgrade failed", result.stderr)
+        self.assertEqual(
+            self.apk_calls(),
+            [
+                ["update"],
+                ["add", "xray-mitm", "luci-app-xray-mitm"],
+                ["upgrade", "xray-mitm", "luci-app-xray-mitm"],
+            ],
         )
         self.assertFalse(self.installed_key.exists())
         self.assertFalse(self.repository_file.exists())

--- a/tests/test_signed_feed.py
+++ b/tests/test_signed_feed.py
@@ -15,7 +15,7 @@ WORKFLOW = ROOT / ".github/workflows/publish-feed.yml"
 PUBLIC_KEY = ROOT / "keys/xray-mitm-feed-v1.pem"
 VERSION_CHECK = ROOT / "scripts/check-release-version.sh"
 EXPECTED_KEY_SHA256 = "3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a"
-EXPECTED_INSTALLER_SHA256 = "bbeaa48a19df4939333375d391ca7da4c2baa6095b210252d9cc479434351d4d"
+EXPECTED_INSTALLER_SHA256 = "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405"
 
 
 class SignedFeedTests(unittest.TestCase):
@@ -78,20 +78,21 @@ class SignedFeedTests(unittest.TestCase):
         self.assertIn("/etc/apk/keys", text)
         self.assertIn("/etc/apk/repositories.d", text)
         self.assertRegex(text, r"apk add xray-mitm luci-app-xray-mitm")
-        self.assertNotIn("apk upgrade", text)
+        self.assertRegex(text, r"apk upgrade xray-mitm luci-app-xray-mitm")
+        self.assertNotRegex(text, r"apk upgrade(?:\s|$)(?!xray-mitm)")
         self.assertNotIn("allow-untrusted", text.replace(
             "--allow-untrusted was not used", ""
         ))
 
     def test_release_tag_must_match_package_version(self) -> None:
         good = subprocess.run(
-            ["sh", str(VERSION_CHECK), str(ROOT), "v0.2.1"],
+            ["sh", str(VERSION_CHECK), str(ROOT), "v0.2.2"],
             text=True,
             capture_output=True,
             check=False,
         )
         bad = subprocess.run(
-            ["sh", str(VERSION_CHECK), str(ROOT), "v0.2.2"],
+            ["sh", str(VERSION_CHECK), str(ROOT), "v0.2.3"],
             text=True,
             capture_output=True,
             check=False,

--- a/xray-mitm/Makefile
+++ b/xray-mitm/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-mitm
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-only
 PKG_MAINTAINER:=duuuude


### PR DESCRIPTION
Repeated runs of the authenticated installer configured the signed feed but left existing packages on their old versions because OpenWrt APK v3 did not upgrade them during `apk add`.

The installer now follows installation with a targeted `apk upgrade xray-mitm luci-app-xray-mitm`. This installs missing packages on first use and upgrades only these two packages on later runs. English and Farsi update instructions now use the same targeted command, and release validation rejects any unrestricted upgrade invocation.

Validation:

- `sh scripts/validate-release.sh`
- 9 installer behavior tests, including targeted-upgrade failure rollback
- 7 signed-feed tests
- 6 PassWall2 routing tests
- 4 certificate tests
- 4 startup tests
- init enable guards and shell syntax checks

Version: `0.2.2-r1`
