### PR TITLE
Add v0.4 backend foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added an idempotent Quick Setup backend that preserves existing configuration
+  and certificate state, recovers interrupted certificate work first, starts the
+  service, and enables automatic startup.
+- Added a product-level setup status contract for certificate, service,
+  PassWall2, routing, recovery, and explicitly unchecked health state.
+- Added a supported `xray-mitmctl passwall2` command namespace for inspection,
+  staged plans, apply, rollback, and recovery.
+
+### Changed
+
+- LuCI now reaches PassWall2 operations through the supported `xray-mitmctl`
+  boundary, and obsolete routing request arguments were removed.
+
 ## [0.3.0] - 2026-09-10
 
 ### Changed

--- a/ci/validate_release.py
+++ b/ci/validate_release.py
@@ -127,6 +127,7 @@ ALLOWED_PUBLIC_KEYS = {"keys/xray-mitm-feed-v1.pem"}
 
 MUTATING_RPC_METHODS = {
     "runHealthCheck",
+    "setupRecommended",
     "serviceAction",
     "installDefaultConfig",
     "generateCandidate",
@@ -143,6 +144,7 @@ MUTATING_RPC_METHODS = {
 
 READ_ONLY_RPC_METHODS = {
     "getStatus",
+    "getSetupStatus",
     "getCertificateStatus",
     "exportCertificate",
     "inspectPassWall2",

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -96,10 +96,9 @@ var callRecoverPassWall2 = rpc.declare({
 });
 
 var routingParams = [
-	'shunt_node', 'vpn_node', 'lan_zone', 'gemini', 'android_check',
+	'shunt_node', 'vpn_node', 'gemini', 'android_check',
 	'youtube_control', 'google_mitm', 'meta_mitm', 'fastly_mitm', 'iran_direct', 'accounts_google',
-	'set_default_vpn', 'set_global_shunt', 'set_localhost_proxy_zero',
-	'block_quic'
+	'set_default_vpn', 'set_localhost_proxy_zero'
 ];
 
 var callPlanPassWall2 = rpc.declare({
@@ -539,7 +538,7 @@ return view.extend({
 			var element = document.getElementById('xray-mitm-route-' + name.replace(/_/g, '-'));
 
 			if (!element)
-				return name === 'lan_zone' ? '' : false;
+				return false;
 
 			return element.type === 'checkbox' ? element.checked : element.value;
 		});

--- a/luci-app-xray-mitm/root/usr/share/rpcd/acl.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/rpcd/acl.d/luci-app-xray-mitm.json
@@ -5,6 +5,7 @@
 			"ubus": {
 				"luci.xray-mitm": [
 					"getStatus",
+					"getSetupStatus",
 					"getCertificateStatus",
 					"exportCertificate",
 					"inspectPassWall2"
@@ -15,6 +16,7 @@
 			"ubus": {
 				"luci.xray-mitm": [
 					"runHealthCheck",
+					"setupRecommended",
 					"serviceAction",
 					"installDefaultConfig",
 					"generateCandidate",

--- a/luci-app-xray-mitm/root/usr/share/rpcd/ucode/xray-mitm.uc
+++ b/luci-app-xray-mitm/root/usr/share/rpcd/ucode/xray-mitm.uc
@@ -2,10 +2,9 @@
 
 'use strict';
 
-import { access, mkdtemp, open, popen, rmdir, unlink } from 'fs';
+import { mkdtemp, open, popen, rmdir, unlink } from 'fs';
 
 const CTL = '/usr/sbin/xray-mitmctl';
-const PASSWALL = '/usr/libexec/xray-mitm/passwall2';
 const MAX_JSON = 128 * 1024;
 const MAX_CERT = 32 * 1024;
 const MAX_KEY = 64 * 1024;
@@ -127,15 +126,12 @@ function validPlanRequest(args) {
 		'gemini', 'android_check', 'youtube_control', 'google_mitm',
 		'meta_mitm', 'fastly_mitm',
 		'iran_direct', 'accounts_google', 'set_default_vpn',
-		'set_global_shunt', 'set_localhost_proxy_zero', 'block_quic'
+		'set_localhost_proxy_zero'
 	];
 
 	for (let name in flags)
 		if (type(args[name]) != 'bool')
 			return false;
-
-	if (args.lan_zone != '' && !validSectionId(args.lan_zone))
-		return false;
 
 	return true;
 }
@@ -144,6 +140,18 @@ const methods = {
 	getStatus: {
 		call: function() {
 			return runJson([ CTL, 'status-json' ]);
+		}
+	},
+
+	getSetupStatus: {
+		call: function() {
+			return runJson([ CTL, 'setup-status-json' ]);
+		}
+	},
+
+	setupRecommended: {
+		call: function() {
+			return runJson([ CTL, 'setup-recommended' ]);
 		}
 	},
 
@@ -288,19 +296,13 @@ const methods = {
 
 	inspectPassWall2: {
 		call: function() {
-			if (!access(PASSWALL, 'x'))
-				return { ok: true, available: false, writable: false };
-
-			return runJson([ PASSWALL, 'inspect' ]);
+			return runJson([ CTL, 'passwall2', 'inspect' ]);
 		}
 	},
 
 	recoverPassWall2: {
 		call: function() {
-			if (!access(PASSWALL, 'x'))
-				return resultError('The PassWall2 integration helper is unavailable.');
-
-			return runJson([ PASSWALL, 'recover' ]);
+			return runJson([ CTL, 'passwall2', 'recover' ]);
 		}
 	},
 
@@ -308,7 +310,6 @@ const methods = {
 		args: {
 			shunt_node: '',
 			vpn_node: '',
-			lan_zone: '',
 			gemini: true,
 			android_check: false,
 			youtube_control: false,
@@ -318,9 +319,7 @@ const methods = {
 			iran_direct: true,
 			accounts_google: false,
 			set_default_vpn: false,
-			set_global_shunt: false,
-			set_localhost_proxy_zero: true,
-			block_quic: false
+			set_localhost_proxy_zero: true
 		},
 		call: function(request) {
 			if (!validPlanRequest(request.args))
@@ -338,7 +337,7 @@ const methods = {
 				return resultError('Unable to prepare the routing preview.');
 			}
 
-			let result = runJson([ PASSWALL, 'plan', dir + '/request.json' ]);
+			let result = runJson([ CTL, 'passwall2', 'plan', dir + '/request.json' ]);
 			cleanupPlan(dir);
 			return result;
 		}
@@ -351,7 +350,7 @@ const methods = {
 				!match(request.args.token, /^[a-f0-9]{64}$/))
 				return resultError('Invalid or expired routing preview token.');
 
-			return runJson([ PASSWALL, 'apply', request.args.token ]);
+			return runJson([ CTL, 'passwall2', 'apply', request.args.token ]);
 		}
 	},
 
@@ -362,7 +361,7 @@ const methods = {
 				!match(request.args.transaction, /^[a-f0-9]{64}$/))
 				return resultError('Invalid rollback transaction.');
 
-			return runJson([ PASSWALL, 'rollback', request.args.transaction ]);
+			return runJson([ CTL, 'passwall2', 'rollback', request.args.transaction ]);
 		}
 	}
 };

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -7,6 +7,7 @@ project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/ci/validate_release.py" "$project_dir"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_passwall2.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_certificates.py"
+PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_ctl.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_installer.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_signed_feed.py"
 PYTHONDONTWRITEBYTECODE=1 python3 "$project_dir/tests/test_startup.py"

--- a/tests/fakes/openwrt_cmd.py
+++ b/tests/fakes/openwrt_cmd.py
@@ -299,14 +299,22 @@ def uci_main(argv: list[str]) -> int:
 
 def jsonfilter_main(argv: list[str]) -> int:
     try:
-        input_path = Path(argv[argv.index("-i") + 1])
         expression = argv[argv.index("-e") + 1]
-        data = json.loads(input_path.read_text(encoding="utf-8"))
+        if "-i" in argv:
+            input_path = Path(argv[argv.index("-i") + 1])
+            raw = input_path.read_text(encoding="utf-8")
+        else:
+            raw = argv[argv.index("-s") + 1]
+        data = json.loads(raw)
     except (ValueError, IndexError, OSError, json.JSONDecodeError):
         return fail()
     if not expression.startswith("@."):
         return fail()
-    value = data.get(expression[2:])
+    value = data
+    for part in expression[2:].split("."):
+        if not isinstance(value, dict) or part not in value:
+            return 0
+        value = value[part]
     if value is None:
         return 0
     if isinstance(value, bool):

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Offline tests for the supported xray-mitmctl command boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT = Path(__file__).resolve().parents[1]
+CTL_SOURCE = PROJECT / "xray-mitm/files/usr/sbin/xray-mitmctl"
+LIBEXEC_SOURCE = PROJECT / "xray-mitm/files/usr/libexec/xray-mitm"
+DEFAULT_UCI = PROJECT / "xray-mitm/files/etc/config/xray-mitm"
+SAMPLE = PROJECT / "xray-mitm/files/usr/share/xray-mitm/config.json.example"
+FAKE_COMMAND = PROJECT / "tests/fakes/openwrt_cmd.py"
+
+
+class ControlFixture(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="xray-mitm-ctl-tests-", dir="/tmp"
+        )
+        self.root = Path(self.temporary.name)
+        for relative in (
+            "etc/config", "etc/init.d", "fake-bin", "tmp", "var/lock",
+            "usr/bin", "usr/sbin", "usr/libexec/xray-mitm", "usr/share/xray-mitm",
+            "usr/share/v2ray",
+        ):
+            (self.root / relative).mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(DEFAULT_UCI, self.root / "etc/config/xray-mitm")
+        uci_path = self.root / "etc/config/xray-mitm"
+        uci_path.write_text(
+            uci_path.read_text(encoding="utf-8").replace(
+                "/usr/share/v2ray", str(self.root / "usr/share/v2ray")
+            ),
+            encoding="utf-8",
+        )
+        shutil.copyfile(SAMPLE, self.root / "usr/share/xray-mitm/config.json.example")
+        self.ctl_path = self.root / "usr/sbin/xray-mitmctl"
+        shutil.copyfile(CTL_SOURCE, self.ctl_path)
+        self.ctl_path.chmod(0o755)
+        for name in ("cert", "check", "config", "passwall2", "common.sh"):
+            destination = self.root / "usr/libexec/xray-mitm" / name
+            shutil.copyfile(LIBEXEC_SOURCE / name, destination)
+            destination.chmod(0o644 if name == "common.sh" else 0o755)
+
+        init = self.root / "etc/init.d/xray-mitm"
+        init.write_text(
+            "#!/bin/sh\n"
+            "case \"${1:-}\" in\n"
+            "  running) [ -e \"$XRAY_MITM_TEST_ROOT/tmp/running\" ] ;;\n"
+            "  enabled) [ -e \"$XRAY_MITM_TEST_ROOT/tmp/boot-enabled\" ] ;;\n"
+            "  start|restart)\n"
+            "    [ \"${FAIL_START:-0}\" != 1 ] || exit 1\n"
+            "    touch \"$XRAY_MITM_TEST_ROOT/tmp/running\"\n"
+            "    printf '%s\\n' \"$1\" >>\"$XRAY_MITM_TEST_ROOT/tmp/actions\" ;;\n"
+            "  stop) rm -f \"$XRAY_MITM_TEST_ROOT/tmp/running\" ;;\n"
+            "  enable) touch \"$XRAY_MITM_TEST_ROOT/tmp/boot-enabled\" ;;\n"
+            "  disable) rm -f \"$XRAY_MITM_TEST_ROOT/tmp/boot-enabled\" ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        init.chmod(0o755)
+
+        xray = self.root / "usr/bin/xray"
+        xray.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        xray.chmod(0o755)
+
+        fake_bin = self.root / "fake-bin"
+        for command in ("uci", "jsonfilter", "stat", "flock"):
+            destination = fake_bin / command
+            shutil.copyfile(FAKE_COMMAND, destination)
+            destination.chmod(0o755)
+
+        self.env = os.environ.copy()
+        self.env["XRAY_MITM_TEST_ROOT"] = str(self.root)
+        self.env["XRAY_MITM_LIBEXEC"] = str(self.root / "usr/libexec/xray-mitm")
+        self.env["PATH"] = f"{fake_bin}:{self.env['PATH']}"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def ctl(self, *args: str, status: int = 0, env=None):
+        result = subprocess.run(
+            ["sh", str(self.ctl_path), *args], env=env or self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+        )
+        self.assertEqual(result.returncode, status, result.stdout + result.stderr)
+        return result
+
+    def test_fresh_setup_and_repeat_are_safe(self) -> None:
+        first = json.loads(self.ctl("setup-recommended").stdout)
+        self.assertTrue(first["ready"])
+        self.assertTrue(first["config_created"])
+        self.assertTrue(first["certificate_created"])
+        self.assertTrue(first["certificate_activated"])
+        self.assertTrue(first["service_started"])
+        self.assertTrue(first["boot_enabled"])
+        cert = self.root / "etc/xray-mitm/mycert.crt"
+        key = self.root / "etc/xray-mitm/mycert.key"
+        before = (hashlib.sha256(cert.read_bytes()).hexdigest(), key.resolve())
+
+        second = json.loads(self.ctl("setup-recommended").stdout)
+        self.assertTrue(second["ready"])
+        self.assertFalse(second["changed"])
+        self.assertEqual(before, (hashlib.sha256(cert.read_bytes()).hexdigest(), key.resolve()))
+        self.assertEqual((self.root / "tmp/actions").read_text().splitlines(), ["start"])
+        status = json.loads(self.ctl("setup-status-json").stdout)
+        self.assertEqual(status["setup"], "ready")
+        self.assertEqual(
+            status["passwall2"],
+            {
+                "installed": False,
+                "compatible": False,
+                "shunt_available": False,
+                "vpn_available": False,
+            },
+        )
+        self.assertEqual(
+            status["routing"],
+            {
+                "configured": False,
+                "recommended_matches_current": False,
+                "recovery_pending": False,
+            },
+        )
+        self.assertEqual(status["health"], {"healthy": None})
+
+    def test_existing_custom_config_is_preserved(self) -> None:
+        config = self.root / "etc/xray-mitm/config.json"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text('{"custom":"preserve-me"}\n', encoding="utf-8")
+        original = config.read_bytes()
+        self.assertTrue(json.loads(self.ctl("setup-recommended").stdout)["ready"])
+        self.assertEqual(config.read_bytes(), original)
+
+    def test_valid_legacy_certificate_pair_is_preserved(self) -> None:
+        self.ctl("config-install-default")
+        cert_dir = self.root / "etc/xray-mitm"
+        key = cert_dir / "mycert.key"
+        cert = cert_dir / "mycert.crt"
+        subprocess.run(
+            [
+                "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                "-keyout", str(key), "-out", str(cert), "-days", "30",
+                "-subj", "/CN=Existing-Legacy-CA",
+            ],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        key.chmod(0o600)
+        original = (hashlib.sha256(cert.read_bytes()).hexdigest(),
+                    hashlib.sha256(key.read_bytes()).hexdigest())
+
+        result = json.loads(self.ctl("setup-recommended").stdout)
+        self.assertTrue(result["ready"])
+        self.assertFalse(result["certificate_created"])
+        self.assertEqual(
+            original,
+            (hashlib.sha256(cert.read_bytes()).hexdigest(),
+             hashlib.sha256(key.read_bytes()).hexdigest()),
+        )
+        status = json.loads(self.ctl("setup-status-json").stdout)
+        self.assertTrue(status["certificate"]["ready"])
+        self.assertIsNotNone(status["certificate"]["fingerprint"])
+        self.assertIsNotNone(status["certificate"]["expiry"])
+
+    def test_manual_candidate_requires_attention(self) -> None:
+        self.ctl("config-install-default")
+        generated = json.loads(self.ctl("cert-generate", "Manual-Candidate", "365").stdout)
+        result = json.loads(self.ctl("setup-recommended", status=1).stdout)
+        self.assertEqual(result["error"], "candidate_requires_attention")
+        cert_status = json.loads(self.ctl("cert-status-json").stdout)
+        self.assertEqual(
+            cert_status["slots"]["candidate"]["fingerprint"], generated["fingerprint"]
+        )
+        self.assertIsNone(cert_status["slots"]["current"])
+
+    def test_invalid_legacy_certificate_files_require_attention(self) -> None:
+        self.ctl("config-install-default")
+        cert_dir = self.root / "etc/xray-mitm"
+        (cert_dir / "mycert.crt").write_text("not a certificate\n", encoding="utf-8")
+        key = cert_dir / "mycert.key"
+        key.write_text("not a private key\n", encoding="utf-8")
+        key.chmod(0o600)
+        result = json.loads(self.ctl("setup-recommended", status=1).stdout)
+        self.assertEqual(result["error"], "certificate_requires_attention")
+        self.assertEqual((cert_dir / "mycert.crt").read_text(), "not a certificate\n")
+
+    def test_unsafe_existing_config_is_not_replaced(self) -> None:
+        config = self.root / "etc/xray-mitm/config.json"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.touch()
+        result = json.loads(self.ctl("setup-recommended", status=1).stdout)
+        self.assertEqual(result["error"], "config_requires_attention")
+        self.assertEqual(config.stat().st_size, 0)
+
+    def test_start_failure_is_structured_and_recoverable(self) -> None:
+        failed_env = self.env.copy()
+        failed_env["FAIL_START"] = "1"
+        failed = json.loads(
+            self.ctl("setup-recommended", status=1, env=failed_env).stdout
+        )
+        self.assertEqual(failed["error"], "service_start_failed")
+        self.assertTrue(failed["config_created"])
+        self.assertTrue(failed["certificate_activated"])
+        recovered = json.loads(self.ctl("setup-recommended").stdout)
+        self.assertTrue(recovered["ready"])
+        self.assertFalse(recovered["certificate_created"])
+
+    def test_certificate_recovery_is_attempted_before_setup(self) -> None:
+        recovery = self.root / "etc/xray-mitm/ca/recovery"
+        recovery.parent.mkdir(parents=True, exist_ok=True)
+        recovery.write_text("invalid recovery marker\n", encoding="utf-8")
+        result = json.loads(self.ctl("setup-recommended", status=1).stdout)
+        self.assertEqual(result["error"], "certificate_recovery_failed")
+        self.assertFalse((self.root / "etc/xray-mitm/config.json").exists())
+
+    def test_passwall2_namespace_and_rpcd_boundary(self) -> None:
+        inspect = json.loads(self.ctl("passwall2", "inspect").stdout)
+        self.assertFalse(inspect["available"])
+        rejected = json.loads(
+            self.ctl("passwall2", "apply", "not-a-token", status=1).stdout
+        )
+        self.assertIn("invalid passwall2", rejected["error"])
+        rpc = (
+            PROJECT / "luci-app-xray-mitm/root/usr/share/rpcd/ucode/xray-mitm.uc"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("/usr/libexec/xray-mitm/passwall2", rpc)
+        self.assertIn("[ CTL, 'passwall2', 'inspect' ]", rpc)
+        self.assertIn("[ CTL, 'passwall2', 'plan'", rpc)
+
+    def test_passwall2_namespace_dispatches_every_supported_operation(self) -> None:
+        helper = self.root / "usr/libexec/xray-mitm/passwall2"
+        helper.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$*\" >>\"$XRAY_MITM_TEST_ROOT/tmp/passwall-calls\"\n"
+            "printf '%s\\n' '{\"ok\":true}'\n",
+            encoding="utf-8",
+        )
+        helper.chmod(0o755)
+        request = self.root / "tmp/request.json"
+        request.write_text("{}\n", encoding="utf-8")
+        token = "a" * 64
+        for args in (
+            ("inspect",), ("plan", str(request)), ("apply", token),
+            ("rollback", token), ("recover",),
+        ):
+            self.assertTrue(json.loads(self.ctl("passwall2", *args).stdout)["ok"])
+        self.assertEqual(
+            (self.root / "tmp/passwall-calls").read_text().splitlines(),
+            [
+                "inspect", f"plan {request}", f"apply {token}",
+                f"rollback {token}", "recover",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -107,7 +107,6 @@ tanya.james-dean.net'
 DEFAULT_REQUEST = {
     "shunt_node": "main_shunt",
     "vpn_node": "vpn_node",
-    "lan_zone": "",
     "gemini": True,
     "android_check": True,
     "youtube_control": True,
@@ -117,9 +116,7 @@ DEFAULT_REQUEST = {
     "iran_direct": True,
     "accounts_google": True,
     "set_default_vpn": True,
-    "set_global_shunt": False,
     "set_localhost_proxy_zero": True,
-    "block_quic": False,
 }
 
 

--- a/xray-mitm/files/usr/libexec/xray-mitm/cert
+++ b/xray-mitm/files/usr/libexec/xray-mitm/cert
@@ -331,6 +331,20 @@ status_json() {
 	printf '}}\n'
 }
 
+validate_active() {
+	local current path
+	if [ "$(compat_state 2>/dev/null || true)" = managed ]; then
+		current="$(link_target "$CURRENT_LINK")" || xray_mitm_die "no active managed CA exists"
+		path="$(slot_path "$current")" || xray_mitm_die "active managed CA slot is invalid"
+		validate_pair "$path/mycert.crt" "$path/mycert.key"
+	elif [ -f "$XRAY_MITM_CERT" ] && [ ! -L "$XRAY_MITM_CERT" ] &&
+		[ -f "$XRAY_MITM_KEY" ] && [ ! -L "$XRAY_MITM_KEY" ]; then
+		validate_pair "$XRAY_MITM_CERT" "$XRAY_MITM_KEY"
+	else
+		xray_mitm_die "no active certificate pair exists"
+	fi
+}
+
 normalize_pair_into_slot() {
 	local input_cert input_key slot cert_tmp key_tmp
 	input_cert="$1"; input_key="$2"; slot="$3"
@@ -636,6 +650,10 @@ case "${1:-}" in
 		[ "$#" -eq 1 ] || xray_mitm_die "validate-current takes no arguments"; acquire_lock
 		recover_transaction || xray_mitm_die "interrupted certificate transaction could not be recovered"
 		current="$(link_target "$CURRENT_LINK")" || xray_mitm_die "no active managed CA exists"; validate_slot_for_switch "$current" ;;
+	validate-active)
+		[ "$#" -eq 1 ] || xray_mitm_die "validate-active takes no arguments"; acquire_lock
+		recover_transaction || xray_mitm_die "interrupted certificate transaction could not be recovered"
+		validate_active ;;
 	recover)
 		[ "$#" -eq 1 ] || xray_mitm_die "recover takes no arguments"; acquire_lock
 		recover_transaction || xray_mitm_die "interrupted certificate transaction could not be recovered" ;;
@@ -657,5 +675,5 @@ case "${1:-}" in
 	adopt-legacy)
 		[ "$#" -eq 1 ] || xray_mitm_die "adopt-legacy takes no arguments"; acquire_lock
 		recover_transaction || xray_mitm_die "interrupted certificate transaction could not be recovered"; adopt_legacy ;;
-	*) xray_mitm_die "usage: cert {status-json|export|validate-current|recover|generate|prepare-import|activate|discard|rollback|adopt-legacy}" ;;
+	*) xray_mitm_die "usage: cert {status-json|export|validate-current|validate-active|recover|generate|prepare-import|activate|discard|rollback|adopt-legacy}" ;;
 esac

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -380,12 +380,12 @@ inspect() {
 	acquire_lock
 	if [ -e "$RECOVERY_MARKER" ] || [ -L "$RECOVERY_MARKER" ]; then
 		release_lock
-		printf '%s\n' '{"ok":true,"available":true,"compatible":false,"writable":false,"recovery_pending":true,"schema":"recovery-required","error":"An interrupted routing transaction must be recovered before PassWall2 can be inspected.","capabilities":{"plan":false,"apply":false,"rollback":false,"recover":true,"set_global_shunt":false,"quic_firewall":false,"dns":false}}'
+		printf '%s\n' '{"ok":true,"available":true,"compatible":false,"writable":false,"recovery_pending":true,"schema":"recovery-required","error":"An interrupted routing transaction must be recovered before PassWall2 can be inspected.","capabilities":{"plan":false,"apply":false,"rollback":false,"recover":true,"dns":false}}'
 		return 0
 	fi
 	if ! schema_check; then
 		release_lock
-		printf '%s\n' '{"ok":true,"available":false,"compatible":false,"writable":false,"recovery_pending":false,"schema":"unsupported","error":"PassWall2 UCI schema or required helper files were not detected.","capabilities":{"plan":false,"apply":false,"rollback":false,"recover":false,"set_global_shunt":false,"quic_firewall":false,"dns":false}}'
+		printf '%s\n' '{"ok":true,"available":false,"compatible":false,"writable":false,"recovery_pending":false,"schema":"unsupported","error":"PassWall2 UCI schema or required helper files were not detected.","capabilities":{"plan":false,"apply":false,"rollback":false,"recover":false,"dns":false}}'
 		return 0
 	fi
 
@@ -402,7 +402,11 @@ inspect() {
 	target_count=$INSPECT_COUNT
 	if [ "$shunt_count" -gt 0 ] && [ "$target_count" -gt 0 ]; then compatible=true; else compatible=false; fi
 	if [ "$compatible" = true ] && [ "$pending" = false ]; then writable=true; else writable=false; fi
-	printf ',"compatible":%s,"writable":%s,"truncated":%s,' "$compatible" "$writable" "$([ "$truncated_shunts" -eq 1 ] || [ "$truncated_targets" -eq 1 ] && printf true || printf false)"
+	printf ',"compatible":%s,"writable":%s,"shunt_available":%s,"vpn_available":%s,"truncated":%s,' \
+		"$compatible" "$writable" \
+		"$([ "$shunt_count" -gt 0 ] && printf true || printf false)" \
+		"$([ "$target_count" -gt 0 ] && printf true || printf false)" \
+		"$([ "$truncated_shunts" -eq 1 ] || [ "$truncated_targets" -eq 1 ] && printf true || printf false)"
 	selected_shunt=$(section_option '@global[0]' node)
 	if ! valid_id "$selected_shunt" || [ "$(section_type "$selected_shunt")" != nodes ] || [ "$(section_option "$selected_shunt" protocol)" != _shunt ]; then
 		selected_shunt=''
@@ -467,7 +471,7 @@ inspect() {
 		printf '"rollback_transaction":null,'
 	fi
 	release_lock
-	printf '%s\n' '"capabilities":{"plan":true,"apply":true,"rollback":true,"recover":true,"set_global_shunt":false,"quic_firewall":false,"dns":false},"note":"Node remarks, IDs, types, protocols, and routing state are returned; credentials and full UCI data are never returned."}'
+	printf '%s\n' '"capabilities":{"plan":true,"apply":true,"rollback":true,"recover":true,"dns":false},"note":"Node remarks, IDs, types, protocols, and routing state are returned; credentials and full UCI data are never returned."}'
 }
 
 safe_request_path() {
@@ -756,7 +760,6 @@ plan() {
 
 	shunt=$(request_value "$request" '@.shunt_node')
 	vpn=$(request_value "$request" '@.vpn_node')
-	lan_zone=$(request_value "$request" '@.lan_zone')
 	gemini=$(as_bool "$(request_value "$request" '@.gemini')") || die invalid_request 'gemini must be a boolean.' 65
 	android=$(as_bool "$(request_value "$request" '@.android_check')") || die invalid_request 'android_check must be a boolean.' 65
 	youtube=$(as_bool "$(request_value "$request" '@.youtube_control')") || die invalid_request 'youtube_control must be a boolean.' 65
@@ -766,15 +769,10 @@ plan() {
 	iran=$(as_bool "$(request_value "$request" '@.iran_direct')") || die invalid_request 'iran_direct must be a boolean.' 65
 	accounts_google=$(as_bool "$(request_value "$request" '@.accounts_google')") || die invalid_request 'accounts_google must be a boolean.' 65
 	set_default=$(as_bool "$(request_value "$request" '@.set_default_vpn')") || die invalid_request 'set_default_vpn must be a boolean.' 65
-	set_global=$(as_bool "$(request_value "$request" '@.set_global_shunt')") || die invalid_request 'set_global_shunt must be a boolean.' 65
 	force_localhost=$(as_bool "$(request_value "$request" '@.set_localhost_proxy_zero')") || die invalid_request 'set_localhost_proxy_zero must be a boolean.' 65
-	block_quic=$(as_bool "$(request_value "$request" '@.block_quic')") || die invalid_request 'block_quic must be a boolean.' 65
 
 	valid_id "$shunt" || die invalid_shunt 'The selected shunt section ID is invalid.' 65
 	valid_id "$vpn" || die invalid_vpn_node 'The selected VPN node section ID is invalid.' 65
-	[ -z "$lan_zone" ] || valid_id "$lan_zone" || die invalid_lan_zone 'The LAN zone ID is invalid.' 65
-	[ "$set_global" = 0 ] || die unsupported_scope 'Changing the PassWall2 global node is not supported by this safety-reviewed helper.' 69
-	[ "$block_quic" = 0 ] || die unsupported_scope 'Firewall and QUIC changes are outside this helper and were not applied.' 69
 	[ "$shunt" != "$vpn" ] || die invalid_selection 'The shunt and VPN target must be different sections.' 65
 	[ "$vpn" != "$MITM_NODE" ] || die invalid_selection 'The selected VPN node cannot be the managed MITM SOCKS node.' 65
 	[ "$(section_type "$shunt")" = nodes ] || die invalid_shunt 'The selected shunt section does not exist.' 65

--- a/xray-mitm/files/usr/sbin/xray-mitmctl
+++ b/xray-mitm/files/usr/sbin/xray-mitmctl
@@ -9,6 +9,8 @@ XRAY_MITM_LIBEXEC="${XRAY_MITM_LIBEXEC:-${XRAY_MITM_TEST_ROOT:-}/usr/libexec/xra
 CERT_HELPER="$XRAY_MITM_LIBEXEC/cert"
 CHECK_HELPER="$XRAY_MITM_LIBEXEC/check"
 CONFIG_HELPER="$XRAY_MITM_LIBEXEC/config"
+PASSWALL_HELPER="$XRAY_MITM_LIBEXEC/passwall2"
+SETUP_LOCK="${XRAY_MITM_ROOT}/var/lock/xray-mitm-setup.lock"
 
 capture_file=""
 capture_output=""
@@ -45,6 +47,178 @@ json_success_message() {
 	printf '{"ok":true,"message":'
 	xray_mitm_json_string "$1"
 	printf '}\n'
+}
+
+setup_result() {
+	local ok ready error message
+	ok="$1"; ready="$2"; error="$3"; message="$4"
+	printf '{"ok":%s,"ready":%s,"changed":%s,"config_created":%s,"certificate_created":%s,"certificate_activated":%s,"service_started":%s,"boot_enabled":%s' \
+		"$ok" "$ready" "$setup_changed" "$setup_config_created" "$setup_certificate_created" \
+		"$setup_certificate_activated" "$setup_service_started" "$setup_boot_enabled"
+	if [ -n "$error" ]; then
+		printf ',"error":'; xray_mitm_json_string "$error"
+	fi
+	if [ -n "$message" ]; then
+		printf ',"message":'; xray_mitm_json_string "$message"
+	fi
+	printf '}\n'
+}
+
+setup_fail() {
+	setup_result false false "$1" "$2"
+	return 1
+}
+
+certificate_state() {
+	local output
+	capture_command "$CERT_HELPER" status-json
+	[ "$capture_status" -eq 0 ] || return 1
+	output="$capture_output"
+	setup_current_present="$(jsonfilter -s "$output" -e '@.slots.current.present' 2>/dev/null || true)"
+	setup_candidate_present="$(jsonfilter -s "$output" -e '@.slots.candidate.present' 2>/dev/null || true)"
+	setup_legacy_present="$(jsonfilter -s "$output" -e '@.legacy_pair' 2>/dev/null || true)"
+	setup_invalid_pair="$(jsonfilter -s "$output" -e '@.invalid_pair' 2>/dev/null || true)"
+	case "$setup_current_present" in true|1) setup_current_present=true ;; *) setup_current_present=false ;; esac
+	case "$setup_candidate_present" in true|1) setup_candidate_present=true ;; *) setup_candidate_present=false ;; esac
+	case "$setup_legacy_present" in true|1) setup_legacy_present=true ;; *) setup_legacy_present=false ;; esac
+	case "$setup_invalid_pair" in true|1) setup_invalid_pair=true ;; *) setup_invalid_pair=false ;; esac
+	setup_active_valid=false
+	if [ "$setup_current_present" = true ] || [ "$setup_legacy_present" = true ]; then
+		capture_command "$CERT_HELPER" validate-active
+		[ "$capture_status" -eq 0 ] && setup_active_valid=true
+	fi
+	return 0
+}
+
+json_boolean() {
+	case "$1" in true|1) printf true ;; *) printf false ;; esac
+}
+
+passwall2_state() {
+	local output
+	setup_passwall_available=false; setup_passwall_compatible=false
+	setup_shunt_available=false; setup_vpn_available=false
+	setup_routing_recovery=false; setup_routing_configured=false
+	setup_routing_recommended=false
+	[ -x "$PASSWALL_HELPER" ] || return 0
+	capture_command "$PASSWALL_HELPER" inspect
+	[ "$capture_status" -eq 0 ] || return 0
+	output="$capture_output"
+	setup_passwall_available="$(json_boolean "$(jsonfilter -s "$output" -e '@.available' 2>/dev/null || true)")"
+	setup_passwall_compatible="$(json_boolean "$(jsonfilter -s "$output" -e '@.compatible' 2>/dev/null || true)")"
+	setup_shunt_available="$(json_boolean "$(jsonfilter -s "$output" -e '@.shunt_available' 2>/dev/null || true)")"
+	setup_vpn_available="$(json_boolean "$(jsonfilter -s "$output" -e '@.vpn_available' 2>/dev/null || true)")"
+	setup_routing_recovery="$(json_boolean "$(jsonfilter -s "$output" -e '@.recovery_pending' 2>/dev/null || true)")"
+	setup_route_gemini="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.gemini' 2>/dev/null || true)")"
+	setup_route_android="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.android_check' 2>/dev/null || true)")"
+	setup_route_youtube="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.youtube_control' 2>/dev/null || true)")"
+	setup_route_google="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.google_mitm' 2>/dev/null || true)")"
+	setup_route_meta="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.meta_mitm' 2>/dev/null || true)")"
+	setup_route_fastly="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.fastly_mitm' 2>/dev/null || true)")"
+	setup_route_iran="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.iran_direct' 2>/dev/null || true)")"
+	setup_route_accounts="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.accounts_google' 2>/dev/null || true)")"
+	setup_route_localhost="$(json_boolean "$(jsonfilter -s "$output" -e '@.routing_state.set_localhost_proxy_zero' 2>/dev/null || true)")"
+	if [ "$setup_route_gemini" = true ] && [ "$setup_route_google" = true ] &&
+		[ "$setup_route_iran" = true ] && [ "$setup_route_localhost" = true ]; then
+		setup_routing_configured=true
+	fi
+	if [ "$setup_routing_configured" = true ] && [ "$setup_route_android" = false ] &&
+		[ "$setup_route_youtube" = false ] && [ "$setup_route_meta" = false ] &&
+		[ "$setup_route_fastly" = false ] && [ "$setup_route_accounts" = false ]; then
+		setup_routing_recommended=true
+	fi
+}
+
+setup_status() {
+	local setup_state config_present certificate_ready candidate_attention running boot_enabled ready certificate_fingerprint certificate_expiry
+	config_present=false; certificate_ready=false; candidate_attention=false
+	running=false; boot_enabled=false; ready=false; certificate_fingerprint=''; certificate_expiry=''
+	[ -s "$XRAY_MITM_CONFIG" ] && config_present=true
+	certificate_state || { json_error "certificate status is unavailable"; return 1; }
+	if [ "$setup_active_valid" = true ]; then
+		certificate_ready=true
+	elif [ "$setup_candidate_present" = true ]; then
+		candidate_attention=true
+	fi
+	if [ "$certificate_ready" = true ] && [ -s "$XRAY_MITM_CERT" ]; then
+		certificate_fingerprint="$(xray_mitm_cert_fingerprint "$XRAY_MITM_CERT" 2>/dev/null || true)"
+		certificate_expiry="$(openssl x509 -in "$XRAY_MITM_CERT" -noout -enddate 2>/dev/null | sed 's/^notAfter=//' | cut -c 1-128)"
+	fi
+	xray_mitm_service_running && running=true
+	xray_mitm_boot_enabled && boot_enabled=true
+	passwall2_state
+	if [ "$config_present" = false ]; then setup_state=needs_config
+	elif [ "$candidate_attention" = true ]; then setup_state=candidate_requires_attention
+	elif [ "$certificate_ready" = false ]; then setup_state=needs_certificate
+	elif [ "$running" = false ]; then setup_state=needs_start
+	else setup_state=ready; ready=true
+	fi
+	printf '{"ok":true,"setup":'; xray_mitm_json_string "$setup_state"
+	printf ',"ready":%s,"config":{"present":%s},"certificate":{"ready":%s,"candidate_requires_attention":%s,"requires_attention":%s,"fingerprint":' \
+		"$ready" "$config_present" "$certificate_ready" "$candidate_attention" "$setup_invalid_pair"
+	if [ -n "$certificate_fingerprint" ]; then xray_mitm_json_string "$certificate_fingerprint"; else printf null; fi
+	printf ',"expiry":'
+	if [ -n "$certificate_expiry" ]; then xray_mitm_json_string "$certificate_expiry"; else printf null; fi
+	printf '},"service":{"running":%s,"boot_enabled":%s},' "$running" "$boot_enabled"
+	printf '"passwall2":{"installed":%s,"compatible":%s,"shunt_available":%s,"vpn_available":%s},' \
+		"$setup_passwall_available" "$setup_passwall_compatible" "$setup_shunt_available" "$setup_vpn_available"
+	printf '"routing":{"configured":%s,"recommended_matches_current":%s,"recovery_pending":%s},"health":{"healthy":null}}\n' \
+		"$setup_routing_configured" "$setup_routing_recommended" "$setup_routing_recovery"
+}
+
+setup_recommended() {
+	local fingerprint
+	setup_changed=false; setup_config_created=false; setup_certificate_created=false
+	setup_certificate_activated=false; setup_service_started=false; setup_boot_enabled=false
+	mkdir -p "${SETUP_LOCK%/*}" || { setup_fail setup_lock_failed "Unable to create the setup lock directory."; return 1; }
+	: >"$SETUP_LOCK" || { setup_fail setup_lock_failed "Unable to create the setup lock."; return 1; }
+	chmod 0600 "$SETUP_LOCK" || { setup_fail setup_lock_failed "Unable to secure the setup lock."; return 1; }
+	exec 8>"$SETUP_LOCK"
+	flock -x 8 || { setup_fail setup_lock_failed "Unable to lock automatic setup."; return 1; }
+
+	capture_command "$CERT_HELPER" recover
+	[ "$capture_status" -eq 0 ] || { setup_fail certificate_recovery_failed "An interrupted certificate transaction could not be recovered."; return 1; }
+
+	if [ ! -e "$XRAY_MITM_CONFIG" ] && [ ! -L "$XRAY_MITM_CONFIG" ]; then
+		capture_command "$CONFIG_HELPER" install-default
+		[ "$capture_status" -eq 0 ] || { setup_fail config_install_failed "The packaged default configuration could not be installed."; return 1; }
+		setup_changed=true; setup_config_created=true
+	elif [ ! -s "$XRAY_MITM_CONFIG" ] || [ -L "$XRAY_MITM_CONFIG" ]; then
+		setup_fail config_requires_attention "The existing configuration is empty or unsafe. Review it in Advanced settings."
+		return 1
+	fi
+
+	certificate_state || { setup_fail certificate_status_failed "Certificate status is unavailable."; return 1; }
+	if { [ "$setup_current_present" = true ] || [ "$setup_legacy_present" = true ] || [ "$setup_invalid_pair" = true ]; } &&
+		[ "$setup_active_valid" = false ]; then
+		setup_fail certificate_requires_attention "The existing certificate files are not a valid active CA pair. Review them in Advanced settings."
+		return 1
+	fi
+	if [ "$setup_active_valid" = false ]; then
+		if [ "$setup_candidate_present" = true ]; then
+			setup_fail candidate_requires_attention "A certificate candidate already exists. Review it in Advanced settings."
+			return 1
+		fi
+		capture_command "$CERT_HELPER" generate MITM-DomainFronting 3650
+		[ "$capture_status" -eq 0 ] || { setup_fail certificate_generation_failed "The default certificate could not be generated."; return 1; }
+		fingerprint="$(printf '%s\n' "$capture_output" | tail -n 1 | tr 'A-F' 'a-f')"
+		xray_mitm_valid_fingerprint "$fingerprint" || { setup_fail certificate_generation_failed "Certificate generation returned an invalid fingerprint."; return 1; }
+		setup_changed=true; setup_certificate_created=true
+		capture_command "$CERT_HELPER" activate "$fingerprint"
+		[ "$capture_status" -eq 0 ] || { setup_fail certificate_activation_failed "The generated certificate could not be activated."; return 1; }
+		setup_certificate_activated=true
+	fi
+
+	if ! xray_mitm_service_running; then
+		service_action start >/dev/null || { setup_fail service_start_failed "MITM Domain Fronting could not be started."; return 1; }
+		setup_changed=true; setup_service_started=true
+	fi
+	if ! xray_mitm_boot_enabled; then
+		service_action enable >/dev/null || { setup_fail boot_enable_failed "MITM is running, but automatic startup could not be enabled."; return 1; }
+		setup_changed=true
+	fi
+	setup_boot_enabled=true
+	setup_result true true '' 'Automatic setup completed.'
 }
 
 run_json_passthrough() {
@@ -202,6 +376,14 @@ case "${1:-}" in
 		printf '{"ok":true,"running":%s,"enabled":%s,"configured":%s,"master_enabled":%s,"recovery_pending":%s}\n' \
 			"$running" "$enabled" "$configured" "$master_enabled" "$recovery_pending"
 		;;
+	setup-status-json)
+		[ "$#" -eq 1 ] || { json_error "setup-status-json takes no arguments"; exit 1; }
+		setup_status
+		;;
+	setup-recommended)
+		[ "$#" -eq 1 ] || { json_error "setup-recommended takes no arguments"; exit 1; }
+		setup_recommended
+		;;
 	health-json)
 		capture_command "$CHECK_HELPER"
 		if [ "$capture_status" -eq 0 ]; then
@@ -258,8 +440,22 @@ case "${1:-}" in
 		[ "$#" -eq 1 ] || { json_error "cert-adopt-legacy takes no arguments"; exit 1; }
 		run_certificate_mutation "existing certificate pair adopted" "$CERT_HELPER" adopt-legacy
 		;;
+	passwall2)
+		case "${2:-}" in
+			inspect|recover) [ "$#" -eq 2 ] ;;
+			plan) [ "$#" -eq 3 ] && [ -f "$3" ] ;;
+			apply|rollback) [ "$#" -eq 3 ] && xray_mitm_valid_fingerprint "$3" ;;
+			*) false ;;
+		esac || { json_error "invalid passwall2 command or arguments"; exit 1; }
+		[ -x "$PASSWALL_HELPER" ] || { json_error "PassWall2 integration is unavailable"; exit 1; }
+		if [ "$#" -eq 2 ]; then
+			run_json_passthrough "$PASSWALL_HELPER" "$2"
+		else
+			run_json_passthrough "$PASSWALL_HELPER" "$2" "$3"
+		fi
+		;;
 	*)
-		json_error "usage: xray-mitmctl {status-json|health-json|service|config-install-default|cert-*}"
+		json_error "usage: xray-mitmctl {status-json|setup-status-json|setup-recommended|health-json|service|config-install-default|cert-*|passwall2}"
 		exit 1
 		;;
 esac


### PR DESCRIPTION
## What changed

The current LuCI backend exposes internal PassWall2 helpers directly and has no safe one-action setup contract. This change adds the backend foundation for the v0.4 beginner dashboard:

- adds an idempotent Quick Setup operation that recovers certificate work first, preserves existing configuration and valid active CA material, creates only missing defaults, starts MITM, and enables startup at boot
- stops for manual certificate candidates, invalid certificate files, unsafe configuration, and partial failures with structured errors
- adds a product status contract for setup, certificate, service, PassWall2, routing, recovery, and explicitly unchecked health
- exposes inspect, plan, apply, rollback, and recover through the supported `xray-mitmctl passwall2` namespace
- routes LuCI RPC calls through `xray-mitmctl` and removes obsolete routing arguments
- records the user-facing backend changes under `Unreleased`

Quick Setup does not alter PassWall2 routing, install PassWall2, replace an active CA, overwrite existing configuration, or run a health request during passive status checks.

## Validation

- [x] `sh scripts/validate-release.sh` passes locally, including the new 10-test backend suite
- [x] existing PassWall2, certificate, installer, signed-feed, startup, and init-enable tests pass
- [x] LuCI JavaScript syntax passes with Node
- [x] `git diff --check` passes
- [x] release layout, ACL synchronization, dependency, and secret checks pass
- [x] `CHANGELOG.md` includes the new behavior under `Unreleased`
- [x] no live router state was changed; hardware testing belongs after the dashboard consumes this backend
