### PR TITLE
Add frontend routing state tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added a small frontend state model with Node-based tests for PassWall2
+  selection, routing presets, route status, and setup progress.
 - Added an idempotent Quick Setup backend that preserves existing configuration
   and certificate state, recovers interrupted certificate work first, starts the
   service, and enables automatic startup.

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -3,6 +3,7 @@
 'require rpc';
 'require ui';
 'require dom';
+'require xray-mitm.state';
 
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',
@@ -307,14 +308,15 @@ function statusPill(label, tone) {
 }
 
 function routeStatus(source, active) {
-	if (active)
-		return { label: _('Active now'), tone: 'good' };
-	if (source === 'existing')
-		return { label: _('Existing rule found'), tone: 'info' };
-	if (source === 'managed')
-		return { label: _('Ready but disabled'), tone: 'muted' };
+	var result = state.routeStatus(source, active);
+	var labels = {
+		active: _('Active now'),
+		existing: _('Existing rule found'),
+		managed: _('Ready but disabled'),
+		new: _('Will be created')
+	};
 
-	return { label: _('Will be created'), tone: 'warn' };
+	return { label: labels[result.kind] || labels.new, tone: result.tone };
 }
 
 function simpleCheck(id, label, description, checked, onChange) {
@@ -534,19 +536,17 @@ return view.extend({
 	},
 
 	planRouting: function(ev) {
-		var values = routingParams.map(function(name) {
+		var values = {};
+		routingParams.forEach(function(name) {
 			var element = document.getElementById('xray-mitm-route-' + name.replace(/_/g, '-'));
-
-			if (!element)
-				return false;
-
-			return element.type === 'checkbox' ? element.checked : element.value;
+			values[name] = element && element.type === 'checkbox' ? element.checked :
+				(element ? element.value : false);
 		});
 		var button = ev.currentTarget;
 		var output = document.getElementById('xray-mitm-routing-preview');
 		setBusy(button, true);
 
-		callPlanPassWall2.apply(null, values).then(assertOk).then(L.bind(function(plan) {
+		callPlanPassWall2.apply(null, state.routingArguments(values)).then(assertOk).then(L.bind(function(plan) {
 			this.planToken = plan.no_change === true ? null : (plan.token || null);
 			this.lastPlan = plan;
 			var mitmRequiredButStopped = plan.requires_mitm_running === true &&
@@ -633,41 +633,20 @@ return view.extend({
 	},
 
 	useRecommendedRouting: function() {
-		this.setRoutingChoices({
-			gemini: true,
-			android_check: false,
-			youtube_control: false,
-			google_mitm: true,
-			meta_mitm: false,
-			fastly_mitm: false,
-			iran_direct: true,
-			accounts_google: false,
-			set_default_vpn: false,
-			set_localhost_proxy_zero: true
-		});
+		this.setRoutingChoices(state.recommendedChoices());
 	},
 
 	restoreCurrentRouting: function() {
-		var state = (this.passwall && this.passwall.routing_state) || {};
-		this.setRoutingChoices({
-			gemini: state.gemini === true,
-			android_check: state.android_check === true,
-			youtube_control: state.youtube_control === true,
-			google_mitm: state.google_mitm === true,
-			meta_mitm: state.meta_mitm === true,
-			fastly_mitm: state.fastly_mitm === true,
-			iran_direct: state.iran_direct === true,
-			accounts_google: state.accounts_google === true,
-			set_default_vpn: state.set_default_vpn === true,
-			set_localhost_proxy_zero: state.set_localhost_proxy_zero === true
-		});
+		var routingState = (this.passwall && this.passwall.routing_state) || {};
+		this.setRoutingChoices(state.routingChoices(routingState));
 	},
 
 	renderSetupGuide: function(status, certificates, passwall) {
 		var current = slotData(certificates, 'current');
 		var routing = (passwall && passwall.routing_state) || {};
-		var routingReady = routing.google_mitm === true || routing.gemini === true || routing.iran_direct === true;
-		var firstTime = status.configured !== true || !slotPresent(current);
+		var progress = state.setupProgress(status, certificates, { routing_state: routing });
+		var routingReady = progress.routingReady;
+		var firstTime = progress.firstTime;
 		var steps = [
 			{
 				number: '1',
@@ -851,13 +830,14 @@ return view.extend({
 	renderRouting: function(inspect) {
 		var shunts = optionList(inspect.shunt_nodes || inspect.shunts);
 		var vpns = optionList(inspect.vpn_nodes || inspect.vpns);
+		var selection = state.passwallSelection(inspect);
 		var capabilities = inspect.capabilities || {};
 		var recoveryPending = inspect.recovery_pending === true;
-		var compatible = !!(inspect.available !== false && inspect.compatible === true && shunts.length && vpns.length);
+		var compatible = selection.compatible;
 		var canPlan = !recoveryPending && compatible && inspect.writable === true && capabilities.plan !== false;
 		var canRollback = !recoveryPending && capabilities.rollback !== false && !!this.rollbackTransaction;
-		var selectedShunt = inspect.selected_shunt || inspect.current_shunt || (shunts[0] && shunts[0].id);
-		var selectedVpn = inspect.selected_vpn || (vpns[0] && vpns[0].id);
+		var selectedShunt = selection.selectedShunt;
+		var selectedVpn = selection.selectedVpn;
 		var routingState = inspect.routing_state || {};
 		var ruleSources = inspect.rule_sources || {};
 		var mitmNode = inspect.mitm_node || {};

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
@@ -1,0 +1,178 @@
+'use strict';
+
+function arrayValue(value) {
+	return Array.isArray(value) ? value : [];
+}
+
+function nodeId(item) {
+	if (typeof item === 'string')
+		return item;
+
+	return item && (item.id || item.name || item.section);
+}
+
+function nodeItems(value) {
+	return arrayValue(value).map(function(item) {
+		var id = nodeId(item);
+
+		return id ? { id: id, raw: item } : null;
+	}).filter(function(item) { return !!item; });
+}
+
+function passwallSelection(passwall) {
+	passwall = passwall || {};
+
+	var shuntItems = passwall.shunt_nodes || passwall.shunts;
+	var vpnItems = passwall.vpn_nodes || passwall.vpns;
+	var shunts = nodeItems(shuntItems);
+	var vpns = nodeItems(vpnItems);
+	var selectedShunt = passwall.selected_shunt || passwall.current_shunt ||
+		(shunts[0] && shunts[0].id);
+	var selectedVpn = passwall.selected_vpn || (vpns[0] && vpns[0].id);
+
+	return {
+		shunts: shunts,
+		vpns: vpns,
+		selectedShunt: selectedShunt,
+		selectedVpn: selectedVpn,
+		compatible: passwall.available !== false && passwall.compatible === true &&
+			shunts.length > 0 && vpns.length > 0
+	};
+}
+
+function certificateSlot(certificates, name) {
+	certificates = certificates || {};
+
+	if (certificates.slots && certificates.slots[name])
+		return certificates.slots[name];
+
+	return certificates[name] || {};
+}
+
+function slotPresent(slot) {
+	return !!(slot && (slot.present === true || slot.fingerprint));
+}
+
+function deriveSimpleState(setup, status, certificates, passwall) {
+	setup = setup || {};
+	status = status || {};
+	certificates = certificates || {};
+	passwall = passwall || {};
+
+	var certificate = setup.certificate || {};
+	var passwallState = setup.passwall2 || {};
+	var routing = setup.routing || {};
+	var selection = passwallSelection(passwall);
+	var certificateReady = certificate.ready === true;
+	var setupBlocked = certificate.candidate_requires_attention === true ||
+		certificate.requires_attention === true;
+
+	return {
+		certificateReady: certificateReady,
+		setupBlocked: setupBlocked,
+		setupComplete: setup.ready === true && !!setup.service &&
+			setup.service.boot_enabled === true,
+		passwallInstalled: passwallState.installed === true,
+		shuntAvailable: passwallState.shunt_available === true,
+		vpnAvailable: passwallState.vpn_available === true,
+		passwallCompatible: passwallState.compatible === true,
+		mitmRunning: status.running === true,
+		canReviewRouting: passwallState.compatible === true && passwall.writable === true &&
+			routing.recovery_pending !== true && selection.shunts.length > 0 &&
+			selection.vpns.length > 0,
+		selectedVpn: selection.selectedVpn,
+		selection: selection,
+		routing: routing,
+		passwallState: passwallState
+	};
+}
+
+function routingChoices(routing) {
+	routing = routing || {};
+
+	return {
+		gemini: routing.gemini === true,
+		android_check: routing.android_check === true,
+		youtube_control: routing.youtube_control === true,
+		google_mitm: routing.google_mitm === true,
+		meta_mitm: routing.meta_mitm === true,
+		fastly_mitm: routing.fastly_mitm === true,
+		iran_direct: routing.iran_direct === true,
+		accounts_google: routing.accounts_google === true,
+		set_default_vpn: routing.set_default_vpn === true,
+		set_localhost_proxy_zero: routing.set_localhost_proxy_zero === true
+	};
+}
+
+function recommendedChoices() {
+	return {
+		gemini: true,
+		android_check: false,
+		youtube_control: false,
+		google_mitm: true,
+		meta_mitm: false,
+		fastly_mitm: false,
+		iran_direct: true,
+		accounts_google: false,
+		set_default_vpn: false,
+		set_localhost_proxy_zero: true
+	};
+}
+
+function routingArguments(values) {
+	values = values || {};
+
+	return [
+		values.shunt_node,
+		values.vpn_node,
+		values.gemini,
+		values.android_check,
+		values.youtube_control,
+		values.google_mitm,
+		values.meta_mitm,
+		values.fastly_mitm,
+		values.iran_direct,
+		values.accounts_google,
+		values.set_default_vpn,
+		values.set_localhost_proxy_zero
+	];
+}
+
+function routeStatus(source, active) {
+	if (active)
+		return { kind: 'active', tone: 'good' };
+	if (source === 'existing')
+		return { kind: 'existing', tone: 'info' };
+	if (source === 'managed')
+		return { kind: 'managed', tone: 'muted' };
+
+	return { kind: 'new', tone: 'warn' };
+}
+
+function setupProgress(status, certificates, passwall) {
+	status = status || {};
+	var current = certificateSlot(certificates, 'current');
+	var routing = (passwall && passwall.routing_state) || {};
+
+	return {
+		firstTime: status.configured !== true || !slotPresent(current),
+		serviceReady: status.configured === true,
+		certificateReady: slotPresent(current),
+		mitmRunning: status.running === true,
+		routingReady: routing.google_mitm === true || routing.gemini === true ||
+			routing.iran_direct === true
+	};
+}
+
+return {
+		certificateSlot: certificateSlot,
+		deriveSimpleState: deriveSimpleState,
+		nodeItems: nodeItems,
+		passwallSelection: passwallSelection,
+		recommendedChoices: recommendedChoices,
+		routeStatus: routeStatus,
+		routingArguments: routingArguments,
+		routingChoices: routingChoices,
+		setupProgress: setupProgress,
+		slotPresent: slotPresent
+};

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -33,6 +33,8 @@ sh "$project_dir/ci/test-init-enable.sh"
 
 if command -v node >/dev/null 2>&1; then
 	node --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js"
+	node --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js"
+	node "$project_dir/tests/test_frontend_state.js"
 	printf '%s\n' 'Shell and LuCI JavaScript syntax checks passed.'
 else
 	printf '%s\n' 'Shell syntax checks passed; LuCI JavaScript syntax check skipped (Node.js not installed).'

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
+	'luci-static', 'resources', 'xray-mitm', 'state.js');
+const state = Function(fs.readFileSync(modulePath, 'utf8'))();
+
+function testPasswallSelection() {
+	const selection = state.passwallSelection({
+		shunts: [ { section: 'shunt-a' } ],
+		vpns: [ { name: 'vpn-a' }, 'vpn-b' ],
+		selected_vpn: 'vpn-b',
+		compatible: true
+	});
+
+	assert.deepStrictEqual(selection.shunts.map(item => item.id), [ 'shunt-a' ]);
+	assert.deepStrictEqual(selection.vpns.map(item => item.id), [ 'vpn-a', 'vpn-b' ]);
+	assert.strictEqual(selection.selectedShunt, 'shunt-a');
+	assert.strictEqual(selection.selectedVpn, 'vpn-b');
+	assert.strictEqual(selection.compatible, true);
+}
+
+function testSimpleState() {
+	const result = state.deriveSimpleState({
+		ready: true,
+		service: { boot_enabled: true },
+		certificate: {
+			ready: false,
+			candidate_requires_attention: true
+		},
+		passwall2: {
+			installed: true,
+			shunt_available: true,
+			vpn_available: true,
+			compatible: true
+		},
+		routing: { recovery_pending: false }
+	}, { running: false }, {}, {
+		shunt_nodes: [ 'shunt-a' ],
+		vpn_nodes: [ 'vpn-a' ],
+		writable: true,
+		compatible: true
+	});
+
+	assert.strictEqual(result.setupComplete, true);
+	assert.strictEqual(result.setupBlocked, true);
+	assert.strictEqual(result.mitmRunning, false);
+	assert.strictEqual(result.canReviewRouting, true);
+	assert.strictEqual(result.selectedVpn, 'vpn-a');
+}
+
+function testRoutingArguments() {
+	const values = state.recommendedChoices();
+	values.shunt_node = 'shunt-a';
+	values.vpn_node = 'vpn-a';
+
+	assert.deepStrictEqual(state.routingArguments(values), [
+		'shunt-a', 'vpn-a', true, false, false, true,
+		false, false, true, false, false, true
+	]);
+
+	assert.strictEqual(state.routingChoices({ google_mitm: 1 }).google_mitm, false);
+	assert.strictEqual(state.routingChoices({ google_mitm: true }).google_mitm, true);
+}
+
+function testRouteStatusAndProgress() {
+	assert.deepStrictEqual(state.routeStatus('existing', false), { kind: 'existing', tone: 'info' });
+	assert.deepStrictEqual(state.routeStatus('managed', false), { kind: 'managed', tone: 'muted' });
+	assert.deepStrictEqual(state.routeStatus(undefined, true), { kind: 'active', tone: 'good' });
+
+	const progress = state.setupProgress({ configured: true, running: true }, {
+		slots: { current: { present: true } }
+	}, { routing_state: { iran_direct: true } });
+
+	assert.deepStrictEqual(progress, {
+		firstTime: false,
+		serviceReady: true,
+		certificateReady: true,
+		mitmRunning: true,
+		routingReady: true
+	});
+}
+
+testPasswallSelection();
+testSimpleState();
+testRoutingArguments();
+testRouteStatusAndProgress();
+console.log('Frontend state tests passed.');


### PR DESCRIPTION
## What changed

Extracts the reusable frontend state logic from the LuCI dashboard and adds focused tests for:

- PassWall2 shunt and VPN selection
- Recommended routing choices
- Routing preview arguments
- Rule status labels
- Setup progress

The current dashboard now uses these shared helpers for routing selections, presets, setup progress, and preview arguments.

No router configuration, certificate, service, or PassWall2 runtime behavior was changed.

## Validation

- [x] `sh scripts/validate-release.sh` passes locally.
- [x] `git diff --check` passes.
- [x] `CHANGELOG.md` has an entry under `Unreleased`.
- [x] Router testing does not apply; this change only refactors frontend state and tests.
- [x] Existing CA material, service state, and PassWall2 routing are preserved.
- [x] No private keys, credentials, router configurations, backups, or generated packages are included.

Node.js was unavailable locally, so the JavaScript syntax and frontend test commands will be verified by GitHub Actions.