### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-11
+
 ### Added
 
 - Added a small frontend state model with Node-based tests for PassWall2
@@ -112,7 +114,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - LuCI service, certificate lifecycle, health-check, and optional PassWall2 controls.
 - English and Persian installation and operating instructions.
 
-[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.0...v0.2.1

--- a/tests/test_signed_feed.py
+++ b/tests/test_signed_feed.py
@@ -17,6 +17,11 @@ VERSION_CHECK = ROOT / "scripts/check-release-version.sh"
 RELEASE_NOTES = ROOT / "scripts/release-notes.sh"
 EXPECTED_KEY_SHA256 = "3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a"
 EXPECTED_INSTALLER_SHA256 = "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405"
+PACKAGE_VERSION = next(
+    line.split(":=", 1)[1].strip()
+    for line in (ROOT / "xray-mitm/Makefile").read_text(encoding="utf-8").splitlines()
+    if line.startswith("PKG_VERSION:=")
+)
 
 
 class SignedFeedTests(unittest.TestCase):
@@ -87,13 +92,13 @@ class SignedFeedTests(unittest.TestCase):
 
     def test_release_tag_must_match_package_version(self) -> None:
         good = subprocess.run(
-            ["sh", str(VERSION_CHECK), str(ROOT), "v0.3.0"],
+            ["sh", str(VERSION_CHECK), str(ROOT), f"v{PACKAGE_VERSION}"],
             text=True,
             capture_output=True,
             check=False,
         )
         bad = subprocess.run(
-            ["sh", str(VERSION_CHECK), str(ROOT), "v0.3.1"],
+            ["sh", str(VERSION_CHECK), str(ROOT), f"v{PACKAGE_VERSION}-invalid"],
             text=True,
             capture_output=True,
             check=False,

--- a/xray-mitm/Makefile
+++ b/xray-mitm/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-mitm
-PKG_VERSION:=0.3.0
+PKG_VERSION:=0.4.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-only
 PKG_MAINTAINER:=duuuude


### PR DESCRIPTION
## What changed

Prepares the merged v0.4 dashboard and backend for the authenticated v0.4.0 release.

- bumps `PKG_VERSION` to `0.4.0` with `PKG_RELEASE:=1`
- moves the current user-facing changes into the dated `0.4.0` changelog section
- updates the comparison links
- makes the release-version test derive its expected tag from the package metadata

## Validation

- [x] `sh scripts/validate-release.sh` passes locally.
- [x] `git diff --check` passes.
- [x] No private keys, credentials, router configuration, backups, or generated packages are included.
- [ ] GitHub Actions must verify the JavaScript syntax and build.

## Router testing

The router remains unchanged. The signed release will be tested only after this PR is merged and the protected feed workflow publishes it.