### PR TITLE
Fix LuCI state module construction

### DIFF
--- a/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
@@ -1,4 +1,5 @@
 'use strict';
+'require baseclass';
 
 function arrayValue(value) {
 	return Array.isArray(value) ? value : [];
@@ -164,15 +165,15 @@ function setupProgress(status, certificates, passwall) {
 	};
 }
 
-return {
-		certificateSlot: certificateSlot,
-		deriveSimpleState: deriveSimpleState,
-		nodeItems: nodeItems,
-		passwallSelection: passwallSelection,
-		recommendedChoices: recommendedChoices,
-		routeStatus: routeStatus,
-		routingArguments: routingArguments,
-		routingChoices: routingChoices,
-		setupProgress: setupProgress,
-		slotPresent: slotPresent
-};
+return baseclass.extend({
+	certificateSlot: certificateSlot,
+	deriveSimpleState: deriveSimpleState,
+	nodeItems: nodeItems,
+	passwallSelection: passwallSelection,
+	recommendedChoices: recommendedChoices,
+	routeStatus: routeStatus,
+	routingArguments: routingArguments,
+	routingChoices: routingChoices,
+	setupProgress: setupProgress,
+	slotPresent: slotPresent
+});

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -6,7 +6,15 @@ const path = require('path');
 
 const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'xray-mitm', 'state.js');
-const state = Function(fs.readFileSync(modulePath, 'utf8'))();
+const baseclass = {
+	extend: function(methods) {
+		function State() {}
+		State.prototype = methods;
+		return State;
+	}
+};
+const State = Function('baseclass', fs.readFileSync(modulePath, 'utf8'))(baseclass);
+const state = new State();
 
 function testPasswallSelection() {
 	const selection = state.passwallSelection({


### PR DESCRIPTION
## What changed

Fixes the v0.4.0 LuCI dashboard crash:

`"xray-mitm.state" factory yields invalid constructor`

LuCI requires every loaded resource module to return a `baseclass` constructor. The shared frontend state module returned a plain object, so LuCI rejected it before the dashboard could render. The module now extends `baseclass`, and the frontend state test instantiates the module through the same constructor contract.

## Validation

- [x] `sh scripts/validate-release.sh` passed locally.
- [x] `git diff --check` passed.
- [x] Python and shell tests passed.
- [ ] JavaScript state test will run in GitHub Actions because Node.js is not installed locally.
- [x] No router configuration, certificate, service state, or PassWall2 runtime behavior changed.
- [x] No private keys, credentials, router backups, or generated packages included.
