### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-11
+
+### Fixed
+
+- Fixed the LuCI dashboard startup error caused by the shared frontend state
+  module returning an invalid constructor.
+- Added regression coverage for loading the shared state module through LuCI's
+  baseclass module contract.
+
 ## [0.4.0] - 2026-09-11
 
 ### Added
@@ -114,7 +123,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - LuCI service, certificate lifecycle, health-check, and optional PassWall2 controls.
 - English and Persian installation and operating instructions.
 
-[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.1...v0.2.2

--- a/xray-mitm/Makefile
+++ b/xray-mitm/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-mitm
-PKG_VERSION:=0.4.0
+PKG_VERSION:=0.4.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-only
 PKG_MAINTAINER:=duuuude


### PR DESCRIPTION
## What changed

Prepare the v0.4.1 hotfix release after the v0.4.0 LuCI dashboard failed to load with:

`"xray-mitm.state" factory yields invalid constructor`

This release updates the package version and records the fix and regression coverage in the changelog. The underlying LuCI fix was merged in PR #13.

## Validation

- [x] `sh scripts/validate-release.sh` passed locally.
- [x] `sh scripts/check-release-version.sh . v0.4.1` passed.
- [x] `git diff --check` passed.
- [x] No router configuration, certificate, service state, or PassWall2 runtime behavior changed.
- [x] No private keys, credentials, router backups, or generated packages included.
