### PR TITLE
Fix LuCI overview state binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the LuCI overview page failing with `state is not defined` after the
+  v0.4.1 state-module constructor fix.
+- Added an overview-module smoke test that exercises the LuCI state dependency
+  during module loading and setup-guide rendering.
+
 ## [0.4.1] - 2026-09-11
 
 ### Fixed

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -3,7 +3,8 @@
 'require rpc';
 'require ui';
 'require dom';
-'require xray-mitm.state';
+
+var state = require('xray-mitm.state');
 
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -125,9 +125,10 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	const fakeDocument = { createTextNode: function(value) { return value; } };
 	const fakeLuCI = { bind: function(fn, context) { return fn.bind(context); } };
 	const overview = Function(
-		'require', 'E', '_', 'document', 'L',
+		'require', 'view', 'rpc', 'ui', 'dom', 'E', '_', 'document', 'L',
 		fs.readFileSync(overviewPath, 'utf8')
-	)(fakeRequire, fakeElement, function(value) { return value; }, fakeDocument, fakeLuCI);
+	)(fakeRequire, fakeView, fakeRpc, fakeUi, fakeDom, fakeElement,
+		function(value) { return value; }, fakeDocument, fakeLuCI);
 
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -6,6 +6,8 @@ const path = require('path');
 
 const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'xray-mitm', 'state.js');
+const overviewPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
+	'luci-static', 'resources', 'view', 'xray-mitm', 'overview.js');
 const baseclass = {
 	extend: function(methods) {
 		function State() {}
@@ -92,8 +94,49 @@ function testRouteStatusAndProgress() {
 	});
 }
 
+function testOverviewLoadsAndRendersWithLuCIStateDependency() {
+	const fakeView = {
+		extend: function(methods) { return methods; }
+	};
+	const fakeRpc = {
+		declare: function() { return function() {}; }
+	};
+	const fakeUi = {
+		addNotification: function() {},
+		createHandlerFn: function() { return function() {}; }
+	};
+	const fakeDom = { content: function() {} };
+	const fakeState = {
+		setupProgress: function() {
+			return { firstTime: true, routingReady: false };
+		}
+	};
+	const modules = {
+		view: fakeView,
+		rpc: fakeRpc,
+		ui: fakeUi,
+		dom: fakeDom,
+		'xray-mitm.state': fakeState
+	};
+	const fakeRequire = function(name) { return modules[name]; };
+	const fakeElement = function(tag, attributes, children) {
+		return { tag: tag, attributes: attributes, children: children };
+	};
+	const fakeDocument = { createTextNode: function(value) { return value; } };
+	const fakeLuCI = { bind: function(fn, context) { return fn.bind(context); } };
+	const overview = Function(
+		'require', 'E', '_', 'document', 'L',
+		fs.readFileSync(overviewPath, 'utf8')
+	)(fakeRequire, fakeElement, function(value) { return value; }, fakeDocument, fakeLuCI);
+
+	assert.doesNotThrow(function() {
+		overview.renderSetupGuide({ configured: false, running: false }, {}, {});
+	});
+}
+
 testPasswallSelection();
 testSimpleState();
 testRoutingArguments();
 testRouteStatusAndProgress();
+testOverviewLoadsAndRendersWithLuCIStateDependency();
 console.log('Frontend state tests passed.');


### PR DESCRIPTION
## What changed

Fixes the v0.4.1 LuCI startup error:

```text
ReferenceError: state is not defined
```

The overview page declared the `xray-mitm.state` LuCI dependency but did not
bind the returned module to the `state` variable used by the page. This patch
adds the binding and a smoke test that loads the actual overview module with a
LuCI-style dependency environment and renders its setup guide.

## Validation

- [x] `git diff --check` passes.
- [x] `sh scripts/validate-release.sh` passes all non-JavaScript checks.
- [ ] GitHub Actions JavaScript syntax and frontend tests must pass with Node.js.
- [x] No router configuration, certificate, service, or PassWall2 runtime state was changed.
- [x] No private keys, credentials, router backups, or generated packages are included.

This is a corrective patch for v0.4.1. Do not publish v0.4.2 until the full
GitHub Actions validation and OpenWrt APK build pass.
