### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-09-11
+
 ### Fixed
 
 - Fixed the LuCI overview page failing with `state is not defined` after the
@@ -130,7 +132,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - LuCI service, certificate lifecycle, health-check, and optional PassWall2 controls.
 - English and Persian installation and operating instructions.
 
-[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.2.2...v0.3.0

--- a/xray-mitm/Makefile
+++ b/xray-mitm/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-mitm
-PKG_VERSION:=0.4.1
+PKG_VERSION:=0.4.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-only
 PKG_MAINTAINER:=duuuude


### PR DESCRIPTION
## What changed

Prepares the corrective v0.4.2 release for the LuCI overview state-binding fix.

- Bumps the core package from 0.4.1 to 0.4.2.
- Moves the verified regression fix and overview smoke-test notes into the v0.4.2 changelog section.

## Validation

-  passed.
- Release version verified: v0.4.2 (package release r1) passed.
- Release notes generation passed.
- Static release validation passed locally.
- GitHub Actions will run the complete test suite and OpenWrt package build before the signed tag is created.

No router configuration, CA material, service state, or PassWall2 routing is changed by this release-preparation PR.