### PR TITLE
Fix LuCI dependency loading and add real loader test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,9 @@ Describe the concrete problem and resulting behavior.
 - [ ] `git diff --check` passes.
 - [ ] `CHANGELOG.md` has a user-facing entry under `Unreleased`, or this change has no user-facing effect.
 - [ ] Relevant AX4200 behavior was tested, or router testing does not apply.
+- [ ] Every affected LuCI page was loaded and exercised in a local browser against
+      the lab router, with no error notification, blank view, or new console error;
+      or this change cannot affect LuCI.
 - [ ] Existing CA material, service state, and PassWall2 routing were preserved unless intentionally changed.
 - [ ] No private keys, credentials, router configurations, backups, or generated packages are included.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Load the dashboard state helper through LuCI's dependency-injection directive
+  instead of the unavailable CommonJS `require()` function.
+- Make the overview smoke test emulate LuCI dependency injection and reject
+  runtime `require()` calls before a package is built or released.
+
 ## [0.4.2] - 2026-09-11
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,23 @@ For changes that affect packages, services, certificates, LuCI, installation, or
 PassWall2, build the APKs and test them on the lab router. Preserve the active CA,
 service state, and routing unless the change explicitly targets them.
 
+Every LuCI JavaScript, template, style, RPC-response, or ACL change must also pass
+a real local-browser test against the lab router before it is pushed:
+
+1. Install or stage the exact candidate files on the router.
+2. Open the affected LuCI page from a local desktop browser and reload it directly
+   so cached JavaScript is not reused.
+3. Confirm the complete page renders without an error notification or blank view.
+4. Exercise every affected control and state transition, including preview/apply
+   behavior when routing code changed.
+5. Inspect the browser console after the reload and interactions; there must be no
+   new JavaScript errors.
+6. Record the tested commit, router package or staged-file version, page, controls,
+   and result in the pull request.
+
+Static validation and GitHub Actions do not replace this browser test. Do not push,
+merge, tag, or publish a LuCI change when the real page has not passed it.
+
 Verify the affected behavior, update from the prior signed version, rollback when
 relevant, and reboot when startup persistence is in scope. Follow
 `docs/RELEASE_TESTING.md` for a public release.

--- a/docs/RELEASE_TESTING.md
+++ b/docs/RELEASE_TESTING.md
@@ -21,7 +21,28 @@ wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
 
 These checks are offline and do not connect to a router.
 
-## 2. Signed publishing checks
+## 2. Local LuCI browser gate
+
+This gate is required for every change that can affect a LuCI page, including its
+JavaScript, templates, styles, RPC data, and ACL access.
+
+1. Install or stage the exact release candidate on the lab router.
+2. Open each affected page in a local desktop browser and reload it directly to
+   bypass stale LuCI JavaScript.
+3. Confirm the full page renders without an error notification or blank view.
+4. Exercise all affected controls and state transitions. For routing changes,
+   verify selection persistence, review/preview, apply, and return-to-page state.
+5. Inspect the browser console after loading and interacting; confirm no new
+   JavaScript errors were recorded.
+6. Confirm the CA, standalone service state, boot state, and PassWall2 routing were
+   preserved unless the release intentionally changes them.
+7. Save the tested commit, candidate version, page, control results, console result,
+   and any screenshot in the release or pull-request evidence.
+
+A syntax check, mocked frontend test, successful APK build, or green GitHub Actions
+run is insufficient by itself. Do not merge or publish until this gate passes.
+
+## 3. Signed publishing checks
 
 Before the tag:
 
@@ -39,7 +60,7 @@ After approving the tagged workflow:
 4. Confirm Pages serves the key and `feed/25.12/all/packages.adb` over HTTPS.
 5. Independently verify key SHA-256 `3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a`.
 
-## 3. Clean-router installation
+## 4. Clean-router installation
 
 Use a disposable or lab router:
 
@@ -56,7 +77,7 @@ Use a disposable or lab router:
 11. Confirm a MITM domain shows `CN=MITM-DomainFronting` while a control domain shows its public issuer.
 12. Reboot and repeat service, routing, health, and client checks.
 
-## 4. Existing-router update
+## 5. Existing-router update
 
 1. Start with a working prior version, active CA, boot setting, and known PassWall2 routing.
 2. Run the same one-command installer.

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -3,8 +3,7 @@
 'require rpc';
 'require ui';
 'require dom';
-
-var state = require('xray-mitm.state');
+'require xray-mitm.state as state';
 
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -8,6 +8,30 @@ const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'xray-mitm', 'state.js');
 const overviewPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'view', 'xray-mitm', 'overview.js');
+
+function loadLuciModule(moduleSource, modules, globals) {
+	const dependencies = [];
+	const directivePattern = /^\s*'require\s+([^\s']+)(?:\s+as\s+([A-Za-z_$][\w$]*))?';\s*$/gm;
+	let match;
+
+	while ((match = directivePattern.exec(moduleSource)) !== null) {
+		const moduleName = match[1];
+		const binding = match[2] || moduleName.split('.').pop();
+
+		assert.ok(Object.prototype.hasOwnProperty.call(modules, moduleName),
+			'LuCI dependency is available: ' + moduleName);
+		dependencies.push({ binding: binding, value: modules[moduleName] });
+	}
+
+	const globalNames = Object.keys(globals || {});
+	const parameterNames = dependencies.map(item => item.binding).concat(globalNames);
+	const parameterValues = dependencies.map(item => item.value)
+		.concat(globalNames.map(name => globals[name]));
+
+	return Function.apply(null, parameterNames.concat(moduleSource))
+		.apply(null, parameterValues);
+}
+
 const baseclass = {
 	extend: function(methods) {
 		function State() {}
@@ -118,17 +142,22 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		dom: fakeDom,
 		'xray-mitm.state': fakeState
 	};
-	const fakeRequire = function(name) { return modules[name]; };
 	const fakeElement = function(tag, attributes, children) {
 		return { tag: tag, attributes: attributes, children: children };
 	};
 	const fakeDocument = { createTextNode: function(value) { return value; } };
 	const fakeLuCI = { bind: function(fn, context) { return fn.bind(context); } };
-	const overview = Function(
-		'require', 'view', 'rpc', 'ui', 'dom', 'E', '_', 'document', 'L',
-		fs.readFileSync(overviewPath, 'utf8')
-	)(fakeRequire, fakeView, fakeRpc, fakeUi, fakeDom, fakeElement,
-		function(value) { return value; }, fakeDocument, fakeLuCI);
+	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
+
+	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
+		'LuCI modules must use loader directives instead of CommonJS require()');
+
+	const overview = loadLuciModule(overviewSource, modules, {
+		E: fakeElement,
+		_: function(value) { return value; },
+		document: fakeDocument,
+		L: fakeLuCI
+	});
 
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});


### PR DESCRIPTION
## What changed

The v0.4.2 LuCI dashboard called CommonJS `require()` at runtime, but LuCI only injects dependencies declared with loader directives. Opening **Services -> MITM Domain Fronting** therefore failed with `ReferenceError: require is not defined`.

This change loads `xray-mitm.state` through LuCI's alias directive. The frontend test harness now emulates LuCI dependency injection and rejects runtime `require()` calls, so this exact failure is caught before packaging.

The contributor guide, release test plan, and pull-request checklist now require every LuCI-affecting change to be loaded and exercised on the lab router through a local browser, with the browser console checked, before push, merge, tag, or release. Green static checks and CI alone no longer satisfy the LuCI gate.

## Validation

- [x] `sh scripts/validate-release.sh` passed locally with bundled Node.js and Homebrew OpenSSL.
- [x] Frontend state tests and JavaScript syntax checks passed.
- [x] The candidate one-line loader fix was staged on the AX4200 and the complete dashboard rendered in Chrome without a new console error.
- [x] `git diff --check` passed.
- [x] The standalone MITM service remained stopped and disabled at boot.
- [x] Existing CA material and PassWall2 routing were not changed.
- [x] No private keys, credentials, router configurations, backups, or generated packages are included.
