### PR TITLE
Split LuCI dashboard into routed tabs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,8 @@ Describe the concrete problem and resulting behavior.
 - [ ] Every affected LuCI page was loaded and exercised in a local browser against
       the lab router, with no error notification, blank view, or new console error;
       or this change cannot affect LuCI.
+- [ ] The project owner visually reviewed and explicitly approved the exact tested
+      UI candidate, or this change cannot affect the UI.
 - [ ] Existing CA material, service state, and PassWall2 routing were preserved unless intentionally changed.
 - [ ] No private keys, credentials, router configurations, backups, or generated packages are included.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Replace the long Basic and Advanced dashboards with native LuCI routed tabs.
+  Each tab now has its own URL and renders only its relevant section.
+
 ### Fixed
 
 - Load the dashboard state helper through LuCI's dependency-injection directive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Replace the long Basic and Advanced dashboards with native LuCI routed tabs.
-  Each tab now has its own URL and renders only its relevant section.
+- Replace the long Basic and Advanced dashboards with PassWall2-style tabs.
+  Switching tabs is immediate and shows only the selected section without
+  reloading the LuCI page.
+- Add a shared PassWall2-style status strip to both Basic and Advanced Overview,
+  showing MITM, PassWall2 routing, and certificate readiness at a glance.
+- Show the application version beside the dashboard title for easier support and
+  update checks.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ a real local-browser test against the lab router before it is pushed:
 Static validation and GitHub Actions do not replace this browser test. Do not push,
 merge, tag, or publish a LuCI change when the real page has not passed it.
 
+After the browser test passes, show the exact tested UI candidate to the project
+owner and obtain explicit visual approval. Do not push, merge, tag, or publish a
+UI-affecting change until that approval is recorded; passing tests or silence do
+not count as approval.
+
 Verify the affected behavior, update from the prior signed version, rollback when
 relevant, and reboot when startup persistence is in scope. Follow
 `docs/RELEASE_TESTING.md` for a public release.

--- a/docs/RELEASE_TESTING.md
+++ b/docs/RELEASE_TESTING.md
@@ -38,9 +38,12 @@ JavaScript, templates, styles, RPC data, and ACL access.
    preserved unless the release intentionally changes them.
 7. Save the tested commit, candidate version, page, control results, console result,
    and any screenshot in the release or pull-request evidence.
+8. Present the exact tested UI candidate to the project owner and record explicit
+   visual approval before pushing, merging, tagging, or publishing it.
 
 A syntax check, mocked frontend test, successful APK build, or green GitHub Actions
-run is insufficient by itself. Do not merge or publish until this gate passes.
+run is insufficient by itself. The owner's silence is not UI approval. Do not push,
+merge, tag, or publish until both the browser test and visual approval pass.
 
 ## 3. Signed publishing checks
 

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -5,6 +5,9 @@
 'require dom';
 'require xray-mitm.state as state';
 
+/* Keep this fallback synchronized with xray-mitm/Makefile PKG_VERSION. */
+var PROJECT_VERSION = '0.4.2';
+
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',
 	method: 'getStatus',
@@ -529,57 +532,73 @@ return view.extend({
 			dom.content(target, statusPill(label, tone));
 	},
 
-	routeContext: function() {
-		var path = (L.env && L.env.dispatchpath) || [];
-		var mode = path[3] === 'advanced' ? 'advanced' : 'basic';
-		var allowed = mode === 'advanced' ?
-			[ 'overview', 'service', 'certificates', 'routing' ] :
-			[ 'overview', 'setup', 'routing', 'status' ];
-		var page = path[4] || 'overview';
-
-		return {
-			mode: mode,
-			page: allowed.indexOf(page) > -1 ? page : 'overview'
-		};
-	},
-
-	pageNavigation: function(route) {
+	pageNavigation: function() {
 		var groups = [
 			{ name: 'basic', label: _('Basic') },
 			{ name: 'advanced', label: _('Advanced') }
 		];
-		var pages = route.mode === 'advanced' ? [
+		var advancedPages = [
 			{ name: 'overview', label: _('Overview') },
 			{ name: 'service', label: _('Service') },
 			{ name: 'certificates', label: _('Certificates') },
 			{ name: 'routing', label: _('Routing') }
-		] : [
+		];
+		var basicPages = [
 			{ name: 'overview', label: _('Overview') },
 			{ name: 'setup', label: _('Setup') },
 			{ name: 'routing', label: _('Routing') },
 			{ name: 'status', label: _('Status') }
 		];
-		var tabRow = function(items, active, href) {
-			return E('ul', { class: 'tabs', style: 'margin-bottom:.5rem' }, items.map(function(item) {
-				return E('li', { class: item.name === active ? 'active' : '' }, E('a', {
-					href: href(item.name)
+		var tabRow = function(items, mode, active, style) {
+			return E('ul', {
+				class: 'cbi-tabmenu',
+				'data-dashboard-tabs': mode,
+				style: style || ''
+			}, items.map(function(item) {
+				return E('li', {
+					class: item.name === active ? 'cbi-tab' : 'cbi-tab-disabled',
+					'data-dashboard-tab-mode': mode,
+					'data-dashboard-tab-page': item.name
+				}, E('a', {
+					href: '#',
+					click: ui.createHandlerFn(this, 'switchDashboardPage', mode, item.name)
 				}, item.label));
-			}));
-		};
+			}, this));
+		}.bind(this);
 
 		return E('nav', { 'aria-label': _('MITM Domain Fronting pages') }, [
-			tabRow(groups, route.mode, function(mode) {
-				return L.url('admin/services/xray-mitm/' + mode + '/overview');
-			}),
-			tabRow(pages, route.page, function(page) {
-				return L.url('admin/services/xray-mitm/' + route.mode + '/' + page);
-			})
+			tabRow(groups, 'mode', 'basic'),
+			tabRow(basicPages, 'basic', 'overview'),
+			tabRow(advancedPages, 'advanced', '', 'display:none')
 		]);
 	},
 
-	switchMode: function(mode) {
-		window.location.href = L.url('admin/services/xray-mitm/' +
-			(mode === 'advanced' ? 'advanced' : 'basic') + '/overview');
+	switchDashboardPage: function(mode, page) {
+		var targetPage = mode === 'mode' ? 'overview' : page;
+		var targetMode = mode === 'mode' ? page : mode;
+		var simple = document.getElementById('xray-mitm-simple');
+		var advanced = document.getElementById('xray-mitm-advanced');
+
+		if (simple)
+			simple.style.display = targetMode === 'basic' ? '' : 'none';
+		if (advanced)
+			advanced.style.display = targetMode === 'advanced' ? '' : 'none';
+
+		document.querySelectorAll('[data-dashboard-panel-mode]').forEach(function(panel) {
+			panel.style.display = panel.getAttribute('data-dashboard-panel-mode') === targetMode &&
+				panel.getAttribute('data-dashboard-panel-page') === targetPage ? '' : 'none';
+		});
+		document.querySelectorAll('[data-dashboard-tabs]').forEach(function(row) {
+			var name = row.getAttribute('data-dashboard-tabs');
+			row.style.display = name === 'mode' || name === targetMode ? '' : 'none';
+		});
+		document.querySelectorAll('[data-dashboard-tab-mode]').forEach(function(tab) {
+			var tabMode = tab.getAttribute('data-dashboard-tab-mode');
+			var tabPage = tab.getAttribute('data-dashboard-tab-page');
+			var active = tabMode === 'mode' ? tabPage === targetMode :
+				tabMode === targetMode && tabPage === targetPage;
+			tab.className = active ? 'cbi-tab' : 'cbi-tab-disabled';
+		});
 	},
 
 	reviewRecommendedRouting: function(ev) {
@@ -854,6 +873,68 @@ return view.extend({
 		]);
 	},
 
+	overviewStatusStrip: function(status, certificates, passwall) {
+		var passwallState = (this.setup && this.setup.passwall2) || {};
+		var routingState = (passwall && passwall.routing_state) || {};
+		var current = slotData(certificates, 'current');
+		var cards = [
+			{
+				icon: '◆', label: _('MITM service'),
+				value: status.running === true ? _('Running') : _('Stopped'),
+				tone: status.running === true ? 'good' : 'warn', detail: '127.0.0.1:10808'
+			},
+			{
+				icon: '◉', label: _('PassWall2'),
+				value: passwallState.installed === true ? _('Ready') : _('Not detected'),
+				tone: passwallState.installed === true ? 'good' : 'warn', detail: _('Routing integration')
+			},
+			{
+				icon: '↔', label: _('PassWall2 routing'),
+				value: passwallState.shunt_available === true && passwallState.vpn_available === true ?
+					_('Ready') : _('Needs attention'),
+				tone: passwallState.shunt_available === true && passwallState.vpn_available === true ? 'good' : 'warn',
+				detail: routingState.configured === true ? _('Rules configured') : _('Choose your rules')
+			},
+			{
+				icon: '✓', label: _('Public certificate'),
+				value: slotPresent(current) ? _('Ready') : _('Needed'),
+				tone: slotPresent(current) ? 'good' : 'warn', detail: _('Private key stays on router')
+			}
+		];
+		var toneColors = { good: '#2f7d32', warn: '#a15c00' };
+
+		return E('div', {}, [
+			E('style', {}, '@media(max-width:900px){.xray-mitm-status-strip,.xray-mitm-step-strip{grid-template-columns:repeat(2,minmax(0,1fr))!important}}' +
+				'@media(max-width:520px){.xray-mitm-status-strip,.xray-mitm-step-strip{grid-template-columns:1fr!important}}'),
+			E('div', {
+				class: 'xray-mitm-status-strip',
+				style: 'display:grid!important;grid-template-columns:repeat(4,minmax(0,1fr))!important;' +
+					'align-items:stretch;gap:.7rem;width:100%;box-sizing:border-box;' +
+					'padding:.75rem;margin:1rem 0;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(128,128,128,.12)'
+			}, cards.map(function(card) {
+			return E('div', {
+				class: 'xray-mitm-status-card',
+				style: 'display:flex;align-items:center;gap:.8rem;width:100%;min-height:5.25rem;' +
+					'padding:.75rem .9rem;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(0,0,0,.12);box-sizing:border-box'
+			}, [
+				E('span', {
+					'aria-hidden': 'true',
+					style: 'display:inline-flex;align-items:center;justify-content:center;width:2.35rem;height:2.35rem;' +
+						'flex:0 0 2.35rem;border-radius:50%;background:rgba(94,114,228,.16);' +
+						'color:#5e72e4;font-size:1.35rem;font-weight:700'
+				}, card.icon),
+				E('div', { style: 'min-width:0' }, [
+					E('strong', { style: 'display:block;line-height:1.2' }, card.label),
+					E('span', { style: 'display:block;margin-top:.2rem;font-weight:700;color:' + toneColors[card.tone] }, card.value),
+					E('small', { style: 'display:block;margin-top:.15rem;opacity:.72;white-space:nowrap;overflow:hidden;text-overflow:ellipsis' }, card.detail)
+				])
+			]);
+			}))
+		]);
+	},
+
 	simpleRoutingTable: function(routing, passwall) {
 		routing = routing || {};
 		passwall = passwall || {};
@@ -932,14 +1013,10 @@ return view.extend({
 		var pageStyle = function(name) { return page === name ? '' : 'display:none'; };
 
 		return E('div', { id: 'xray-mitm-simple' }, [
-			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section', style: pageStyle('overview') }, [
+			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'overview', style: pageStyle('overview') }, [
 				E('h3', {}, _('Basic settings')),
-				E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(13rem,1fr));gap:.7rem;margin:1rem 0' }, [
-					this.simpleStatusCard(_('MITM service'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn', _('Local SOCKS: 127.0.0.1:10808')),
-					this.simpleStatusCard(_('PassWall2'), passwallState.installed === true ? _('Detected') : _('Not detected'), passwallState.installed === true ? 'good' : 'warn'),
-					this.simpleStatusCard(_('Routing profile'), passwallState.shunt_available === true ? _('Available') : _('Missing'), passwallState.shunt_available === true ? 'good' : 'warn'),
-					this.simpleStatusCard(_('Working VPN'), passwallState.vpn_available === true ? _('Available') : _('Missing'), passwallState.vpn_available === true ? 'good' : 'warn')
-				]),
+				this.overviewStatusStrip(status, certificates, passwall),
 				this.simpleStateRow(_('MITM application'), _('Installed'), 'good', _('The router backend is connected.')),
 				this.simpleStateRow(_('PassWall2'), passwallState.installed === true ? _('Detected') : _('Not detected'),
 					passwallState.installed === true ? 'good' : 'warn'),
@@ -948,7 +1025,8 @@ return view.extend({
 				this.simpleStateRow(_('VPN connection'), passwallState.vpn_available === true ? _('Available') : _('Missing'),
 					passwallState.vpn_available === true ? 'good' : 'warn')
 			]),
-			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section', style: pageStyle('setup') }, [
+			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'setup', style: pageStyle('setup') }, [
 				E('h3', {}, _('Setup')),
 				this.simpleStateRow(_('Router configuration'), setup.config && setup.config.present === true ? _('Ready') : _('Needed'),
 					setup.config && setup.config.present === true ? 'good' : 'warn'),
@@ -965,7 +1043,8 @@ return view.extend({
 					click: ui.createHandlerFn(this, 'setupRecommended')
 				}, setupComplete ? _('Setup complete') : _('Set up automatically')))
 			]),
-			E('div', { class: 'cbi-section', style: pageStyle('setup') }, [
+			E('div', { class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'setup', style: pageStyle('setup') }, [
 				E('h3', {}, _('Certificate for your device')),
 				E('p', {}, _('Devices using MITM websites must trust this public certificate. The private key stays on the router.')),
 				certificateReady && slotPresent(current) ? E('p', {}, E('button', {
@@ -984,7 +1063,8 @@ return view.extend({
 					])
 				])
 			]),
-			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section', style: pageStyle('routing') }, [
+			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'routing', style: pageStyle('routing') }, [
 				E('h3', {}, _('Routing rules')),
 				E('p', {}, _('Choose the service groups to use. The table shows the destination that will be assigned in PassWall2.')),
 				passwallState.installed !== true ? E('div', { class: 'alert-message warning' }, _(
@@ -1008,7 +1088,8 @@ return view.extend({
 					E('div', { id: 'xray-mitm-simple-routing-preview', 'aria-live': 'polite' })
 				]) : ''
 			]),
-			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section', style: pageStyle('status') }, [
+			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'status', style: pageStyle('status') }, [
 				E('h3', {}, _('Status')),
 				this.simpleStateRow(_('MITM'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn'),
 				this.simpleStateRow(_('Routing'), routingState.recommended_matches_current === true ? _('Recommended') :
@@ -1066,10 +1147,18 @@ return view.extend({
 			E('p', {}, firstTime ?
 				_('Complete these steps once, in order. Green items are already ready.') :
 				_('Updates preserve your configuration and certificate. These cards show the current state; complete only items that are not ready.')),
-			E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(14rem,1fr));gap:.75rem' },
-				steps.map(function(step) {
+			this.overviewStatusStrip(status, certificates, passwall),
+			E('div', {
+				class: 'xray-mitm-step-strip',
+				style: 'display:grid!important;grid-template-columns:repeat(4,minmax(0,1fr))!important;' +
+					'align-items:stretch;gap:.7rem;width:100%;box-sizing:border-box;' +
+					'padding:.75rem;margin:1rem 0;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(128,128,128,.12)'
+			}, steps.map(function(step) {
 					return E('div', {
-						style: 'padding:1rem;border:1px solid var(--border-color-medium,#ccc);border-radius:.45rem'
+						style: 'display:flex;flex-direction:column;justify-content:center;width:100%;min-height:5.25rem;' +
+							'padding:.75rem .9rem;border:1px solid var(--border-color-medium,#ccc);' +
+							'border-radius:.35rem;background:rgba(0,0,0,.12);box-sizing:border-box'
 					}, [
 						E('div', { style: 'display:flex;align-items:center;gap:.55rem;margin-bottom:.45rem' }, [
 							statusPill(step.done ? '✓' : (firstTime ? step.number : '!'), step.done ? 'good' : 'warn'),
@@ -1346,33 +1435,46 @@ return view.extend({
 		this.status = data[1] || {};
 		this.certificates = data[2] || {};
 		this.passwall = data[3] || {};
+		this.appVersion = text(this.setup.app_version || this.setup.version, PROJECT_VERSION)
+			.replace(/^v/i, '');
 		this.planToken = null;
 		this.rollbackTransaction = this.passwall.rollback_transaction || null;
-		var route = this.routeContext();
-		var advancedPages = {
-			overview: this.renderSetupGuide(this.status, this.certificates, this.passwall),
-			service: this.renderService(this.status),
-			certificates: this.renderCertificates(this.certificates),
-			routing: this.renderRouting(this.passwall)
-		};
 
 		return E('div', {}, [
-			E('h2', {}, _('MITM Domain Fronting')),
+			E('h2', { style: 'display:flex;align-items:center;gap:.65rem;flex-wrap:wrap' }, [
+				_('MITM Domain Fronting'),
+				E('span', {
+					class: 'xray-mitm-version-badge',
+					title: _('Application version'),
+					style: 'display:inline-block;padding:.18rem .55rem;border:1px solid var(--border-color-medium,#ccc);' +
+						'border-radius:999px;font-size:.55em;font-weight:600;line-height:1.2;opacity:.82'
+				}, 'v' + this.appVersion)
+			]),
 			E('p', {}, _(
 				'Prepare the MITM service, download the public certificate, and configure safe PassWall2 routing.'
 			)),
-			this.pageNavigation(route),
+			this.pageNavigation(),
 			this.setup.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.setup.error, _('Unable to read setup status.'))) : '',
-			route.mode === 'basic' ? this.renderSimple(
-				this.setup, this.status, this.certificates, this.passwall, route.page
-			) : '',
-			route.mode === 'advanced' ? E('div', { id: 'xray-mitm-advanced' }, [
+			this.renderSimple(this.setup, this.status, this.certificates, this.passwall, 'overview'),
+			E('div', { id: 'xray-mitm-advanced', style: 'display:none' }, [
 				E('div', { class: 'alert-message notice' }, _(
 					'Advanced settings expose manual service, certificate, transaction, and routing controls.'
 				)),
-				route.page === 'service' && this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
-				advancedPages[route.page]
-			]) : '',
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'overview', style: 'display:none' },
+				this.renderSetupGuide(this.status, this.certificates, this.passwall)),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'service', style: 'display:none' }, [
+					this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
+					this.renderService(this.status)
+				]),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'certificates', style: 'display:none' },
+				this.renderCertificates(this.certificates)),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'routing', style: 'display:none' },
+				this.renderRouting(this.passwall))
+			]),
 			E('div', { class: 'alert-message warning' }, _(
 				'Trust the public CA only on devices you control. Never copy, publish, or download the router private CA key.'
 			))

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -529,25 +529,57 @@ return view.extend({
 			dom.content(target, statusPill(label, tone));
 	},
 
+	routeContext: function() {
+		var path = (L.env && L.env.dispatchpath) || [];
+		var mode = path[3] === 'advanced' ? 'advanced' : 'basic';
+		var allowed = mode === 'advanced' ?
+			[ 'overview', 'service', 'certificates', 'routing' ] :
+			[ 'overview', 'setup', 'routing', 'status' ];
+		var page = path[4] || 'overview';
+
+		return {
+			mode: mode,
+			page: allowed.indexOf(page) > -1 ? page : 'overview'
+		};
+	},
+
+	pageNavigation: function(route) {
+		var groups = [
+			{ name: 'basic', label: _('Basic') },
+			{ name: 'advanced', label: _('Advanced') }
+		];
+		var pages = route.mode === 'advanced' ? [
+			{ name: 'overview', label: _('Overview') },
+			{ name: 'service', label: _('Service') },
+			{ name: 'certificates', label: _('Certificates') },
+			{ name: 'routing', label: _('Routing') }
+		] : [
+			{ name: 'overview', label: _('Overview') },
+			{ name: 'setup', label: _('Setup') },
+			{ name: 'routing', label: _('Routing') },
+			{ name: 'status', label: _('Status') }
+		];
+		var tabRow = function(items, active, href) {
+			return E('ul', { class: 'tabs', style: 'margin-bottom:.5rem' }, items.map(function(item) {
+				return E('li', { class: item.name === active ? 'active' : '' }, E('a', {
+					href: href(item.name)
+				}, item.label));
+			}));
+		};
+
+		return E('nav', { 'aria-label': _('MITM Domain Fronting pages') }, [
+			tabRow(groups, route.mode, function(mode) {
+				return L.url('admin/services/xray-mitm/' + mode + '/overview');
+			}),
+			tabRow(pages, route.page, function(page) {
+				return L.url('admin/services/xray-mitm/' + route.mode + '/' + page);
+			})
+		]);
+	},
+
 	switchMode: function(mode) {
-		var simple = document.getElementById('xray-mitm-simple');
-		var advanced = document.getElementById('xray-mitm-advanced');
-		var simpleButton = document.getElementById('xray-mitm-mode-simple');
-		var advancedButton = document.getElementById('xray-mitm-mode-advanced');
-		var showAdvanced = mode === 'advanced';
-		if (simple)
-			simple.style.display = showAdvanced ? 'none' : '';
-		if (advanced)
-			advanced.style.display = showAdvanced ? '' : 'none';
-		if (simpleButton)
-			simpleButton.className = showAdvanced ? 'btn' : 'btn cbi-button-action';
-		if (simpleButton)
-			simpleButton.setAttribute('aria-pressed', showAdvanced ? 'false' : 'true');
-		if (advancedButton)
-			advancedButton.className = showAdvanced ? 'btn cbi-button-action' : 'btn';
-		if (advancedButton)
-			advancedButton.setAttribute('aria-pressed', showAdvanced ? 'true' : 'false');
-		window.scrollTo({ top: 0, behavior: 'smooth' });
+		window.location.href = L.url('admin/services/xray-mitm/' +
+			(mode === 'advanced' ? 'advanced' : 'basic') + '/overview');
 	},
 
 	reviewRecommendedRouting: function(ev) {
@@ -822,24 +854,6 @@ return view.extend({
 		]);
 	},
 
-	simpleNavigation: function() {
-		return E('nav', {
-			'aria-label': _('MITM Domain Fronting sections'),
-			style: 'display:flex;gap:.35rem;flex-wrap:wrap;margin:1rem 0'
-		}, [
-			[ 'xray-mitm-simple-basic', _('Basic settings') ],
-			[ 'xray-mitm-simple-certificate', _('Certificate') ],
-			[ 'xray-mitm-simple-routing', _('Routing rules') ],
-			[ 'xray-mitm-simple-status', _('Status') ]
-		].map(function(item) {
-			return E('a', {
-				href: '#' + item[0],
-				class: 'btn',
-				style: 'text-decoration:none'
-			}, item[1]);
-		}));
-	},
-
 	simpleRoutingTable: function(routing, passwall) {
 		routing = routing || {};
 		passwall = passwall || {};
@@ -901,7 +915,7 @@ return view.extend({
 		]));
 	},
 
-	renderSimple: function(setup, status, certificates, passwall) {
+	renderSimple: function(setup, status, certificates, passwall, page) {
 		var current = slotData(certificates, 'current');
 		var certificateReady = setup.certificate && setup.certificate.ready === true;
 		var candidateAttention = setup.certificate && setup.certificate.candidate_requires_attention === true;
@@ -915,10 +929,10 @@ return view.extend({
 			routingState.recovery_pending !== true && shunts.length > 0 && vpns.length > 0;
 		var setupBlocked = candidateAttention || certificateAttention;
 		var setupComplete = setup.ready === true && setup.service && setup.service.boot_enabled === true;
+		var pageStyle = function(name) { return page === name ? '' : 'display:none'; };
 
 		return E('div', { id: 'xray-mitm-simple' }, [
-			this.simpleNavigation(),
-			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section', style: pageStyle('overview') }, [
 				E('h3', {}, _('Basic settings')),
 				E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(13rem,1fr));gap:.7rem;margin:1rem 0' }, [
 					this.simpleStatusCard(_('MITM service'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn', _('Local SOCKS: 127.0.0.1:10808')),
@@ -934,7 +948,7 @@ return view.extend({
 				this.simpleStateRow(_('VPN connection'), passwallState.vpn_available === true ? _('Available') : _('Missing'),
 					passwallState.vpn_available === true ? 'good' : 'warn')
 			]),
-			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section', style: pageStyle('setup') }, [
 				E('h3', {}, _('Setup')),
 				this.simpleStateRow(_('Router configuration'), setup.config && setup.config.present === true ? _('Ready') : _('Needed'),
 					setup.config && setup.config.present === true ? 'good' : 'warn'),
@@ -951,7 +965,7 @@ return view.extend({
 					click: ui.createHandlerFn(this, 'setupRecommended')
 				}, setupComplete ? _('Setup complete') : _('Set up automatically')))
 			]),
-			E('div', { class: 'cbi-section' }, [
+			E('div', { class: 'cbi-section', style: pageStyle('setup') }, [
 				E('h3', {}, _('Certificate for your device')),
 				E('p', {}, _('Devices using MITM websites must trust this public certificate. The private key stays on the router.')),
 				certificateReady && slotPresent(current) ? E('p', {}, E('button', {
@@ -970,7 +984,7 @@ return view.extend({
 					])
 				])
 			]),
-			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section', style: pageStyle('routing') }, [
 				E('h3', {}, _('Routing rules')),
 				E('p', {}, _('Choose the service groups to use. The table shows the destination that will be assigned in PassWall2.')),
 				passwallState.installed !== true ? E('div', { class: 'alert-message warning' }, _(
@@ -994,7 +1008,7 @@ return view.extend({
 					E('div', { id: 'xray-mitm-simple-routing-preview', 'aria-live': 'polite' })
 				]) : ''
 			]),
-			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section', style: pageStyle('status') }, [
 				E('h3', {}, _('Status')),
 				this.simpleStateRow(_('MITM'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn'),
 				this.simpleStateRow(_('Routing'), routingState.recommended_matches_current === true ? _('Recommended') :
@@ -1010,10 +1024,7 @@ return view.extend({
 					class: 'btn cbi-button-action', disabled: status.running === true ? null : '',
 					click: ui.createHandlerFn(this, 'runHealth')
 				}, _('Run check')))
-			]),
-			E('p', {}, E('button', {
-				class: 'btn', click: ui.createHandlerFn(this, 'switchMode', 'advanced')
-			}, _('Advanced settings →')))
+			])
 		]);
 	},
 
@@ -1337,34 +1348,31 @@ return view.extend({
 		this.passwall = data[3] || {};
 		this.planToken = null;
 		this.rollbackTransaction = this.passwall.rollback_transaction || null;
+		var route = this.routeContext();
+		var advancedPages = {
+			overview: this.renderSetupGuide(this.status, this.certificates, this.passwall),
+			service: this.renderService(this.status),
+			certificates: this.renderCertificates(this.certificates),
+			routing: this.renderRouting(this.passwall)
+		};
 
 		return E('div', {}, [
 			E('h2', {}, _('MITM Domain Fronting')),
 			E('p', {}, _(
 				'Prepare the MITM service, download the public certificate, and configure safe PassWall2 routing.'
 			)),
-			E('div', { style: 'display:flex;gap:.5rem;margin:1rem 0' }, [
-				E('button', {
-					id: 'xray-mitm-mode-simple', class: 'btn cbi-button-action', 'aria-pressed': 'true',
-					click: ui.createHandlerFn(this, 'switchMode', 'simple')
-				}, _('Simple')),
-				E('button', {
-					id: 'xray-mitm-mode-advanced', class: 'btn', 'aria-pressed': 'false',
-					click: ui.createHandlerFn(this, 'switchMode', 'advanced')
-				}, _('Advanced'))
-			]),
+			this.pageNavigation(route),
 			this.setup.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.setup.error, _('Unable to read setup status.'))) : '',
-			this.renderSimple(this.setup, this.status, this.certificates, this.passwall),
-			E('div', { id: 'xray-mitm-advanced', style: 'display:none' }, [
+			route.mode === 'basic' ? this.renderSimple(
+				this.setup, this.status, this.certificates, this.passwall, route.page
+			) : '',
+			route.mode === 'advanced' ? E('div', { id: 'xray-mitm-advanced' }, [
 				E('div', { class: 'alert-message notice' }, _(
 					'Advanced settings expose manual service, certificate, transaction, and routing controls.'
 				)),
-				this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
-				this.renderSetupGuide(this.status, this.certificates, this.passwall),
-				this.renderService(this.status),
-				this.renderCertificates(this.certificates),
-				this.renderRouting(this.passwall)
-			]),
+				route.page === 'service' && this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
+				advancedPages[route.page]
+			]) : '',
 			E('div', { class: 'alert-message warning' }, _(
 				'Trust the public CA only on devices you control. Never copy, publish, or download the router private CA key.'
 			))

--- a/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
@@ -2,12 +2,57 @@
 	"admin/services/xray-mitm": {
 		"title": "MITM Domain Fronting",
 		"order": 91,
-		"action": {
-			"type": "view",
-			"path": "xray-mitm/overview"
-		},
-		"depends": {
-			"acl": [ "luci-app-xray-mitm" ]
-		}
+		"action": { "type": "firstchild" },
+		"depends": { "acl": [ "luci-app-xray-mitm" ] }
+	},
+	"admin/services/xray-mitm/basic": {
+		"title": "Basic",
+		"order": 10,
+		"action": { "type": "firstchild" }
+	},
+	"admin/services/xray-mitm/basic/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/setup": {
+		"title": "Setup",
+		"order": 20,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/routing": {
+		"title": "Routing",
+		"order": 30,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/status": {
+		"title": "Status",
+		"order": 40,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced": {
+		"title": "Advanced",
+		"order": 20,
+		"action": { "type": "firstchild" }
+	},
+	"admin/services/xray-mitm/advanced/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/service": {
+		"title": "Service",
+		"order": 20,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/certificates": {
+		"title": "Certificates",
+		"order": 30,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/routing": {
+		"title": "Routing",
+		"order": 40,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
 	}
 }

--- a/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
@@ -2,57 +2,12 @@
 	"admin/services/xray-mitm": {
 		"title": "MITM Domain Fronting",
 		"order": 91,
-		"action": { "type": "firstchild" },
-		"depends": { "acl": [ "luci-app-xray-mitm" ] }
-	},
-	"admin/services/xray-mitm/basic": {
-		"title": "Basic",
-		"order": 10,
-		"action": { "type": "firstchild" }
-	},
-	"admin/services/xray-mitm/basic/overview": {
-		"title": "Overview",
-		"order": 10,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/setup": {
-		"title": "Setup",
-		"order": 20,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/routing": {
-		"title": "Routing",
-		"order": 30,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/status": {
-		"title": "Status",
-		"order": 40,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced": {
-		"title": "Advanced",
-		"order": 20,
-		"action": { "type": "firstchild" }
-	},
-	"admin/services/xray-mitm/advanced/overview": {
-		"title": "Overview",
-		"order": 10,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/service": {
-		"title": "Service",
-		"order": 20,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/certificates": {
-		"title": "Certificates",
-		"order": 30,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/routing": {
-		"title": "Routing",
-		"order": 40,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
+		"action": {
+			"type": "view",
+			"path": "xray-mitm/overview"
+		},
+		"depends": {
+			"acl": [ "luci-app-xray-mitm" ]
+		}
 	}
 }

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -8,6 +8,8 @@ const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'xray-mitm', 'state.js');
 const overviewPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'view', 'xray-mitm', 'overview.js');
+const menuPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'root',
+	'usr', 'share', 'luci', 'menu.d', 'luci-app-xray-mitm.json');
 
 function loadLuciModule(moduleSource, modules, globals) {
 	const dependencies = [];
@@ -146,7 +148,11 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		return { tag: tag, attributes: attributes, children: children };
 	};
 	const fakeDocument = { createTextNode: function(value) { return value; } };
-	const fakeLuCI = { bind: function(fn, context) { return fn.bind(context); } };
+	const fakeLuCI = {
+		bind: function(fn, context) { return fn.bind(context); },
+		env: { dispatchpath: [ 'admin', 'services', 'xray-mitm', 'basic', 'overview' ] },
+		url: function(value) { return '/' + value; }
+	};
 	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
 
 	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
@@ -162,6 +168,28 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});
 	});
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'basic', page: 'overview' });
+	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'certificates' ];
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'certificates' });
+	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'unknown' ];
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'overview' });
+}
+
+function testRoutedPageMenu() {
+	const menu = JSON.parse(fs.readFileSync(menuPath, 'utf8'));
+	const root = 'admin/services/xray-mitm';
+	const pages = [
+		'basic/overview', 'basic/setup', 'basic/routing', 'basic/status',
+		'advanced/overview', 'advanced/service', 'advanced/certificates', 'advanced/routing'
+	];
+
+	assert.strictEqual(menu[root].action.type, 'firstchild');
+	assert.strictEqual(menu[root + '/basic'].action.type, 'firstchild');
+	assert.strictEqual(menu[root + '/advanced'].action.type, 'firstchild');
+	pages.forEach(function(page) {
+		assert.strictEqual(menu[root + '/' + page].action.type, 'view');
+		assert.strictEqual(menu[root + '/' + page].action.path, 'xray-mitm/overview');
+	});
 }
 
 testPasswallSelection();
@@ -169,4 +197,5 @@ testSimpleState();
 testRoutingArguments();
 testRouteStatusAndProgress();
 testOverviewLoadsAndRendersWithLuCIStateDependency();
+testRoutedPageMenu();
 console.log('Frontend state tests passed.');

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -150,13 +150,16 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	const fakeDocument = { createTextNode: function(value) { return value; } };
 	const fakeLuCI = {
 		bind: function(fn, context) { return fn.bind(context); },
-		env: { dispatchpath: [ 'admin', 'services', 'xray-mitm', 'basic', 'overview' ] },
 		url: function(value) { return '/' + value; }
 	};
 	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
 
 	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
 		'LuCI modules must use loader directives instead of CommonJS require()');
+	assert.match(overviewSource, /var PROJECT_VERSION = '0\.4\.2';/,
+		'LuCI dashboard keeps the current project version fallback');
+	assert.match(overviewSource, /xray-mitm-version-badge/,
+		'LuCI dashboard renders a visible application version badge');
 
 	const overview = loadLuciModule(overviewSource, modules, {
 		E: fakeElement,
@@ -168,28 +171,84 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});
 	});
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'basic', page: 'overview' });
-	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'certificates' ];
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'certificates' });
-	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'unknown' ];
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'overview' });
+	assert.strictEqual(typeof overview.switchDashboardPage, 'function');
 }
 
-function testRoutedPageMenu() {
+function testSingleViewMenu() {
 	const menu = JSON.parse(fs.readFileSync(menuPath, 'utf8'));
 	const root = 'admin/services/xray-mitm';
-	const pages = [
-		'basic/overview', 'basic/setup', 'basic/routing', 'basic/status',
-		'advanced/overview', 'advanced/service', 'advanced/certificates', 'advanced/routing'
-	];
 
-	assert.strictEqual(menu[root].action.type, 'firstchild');
-	assert.strictEqual(menu[root + '/basic'].action.type, 'firstchild');
-	assert.strictEqual(menu[root + '/advanced'].action.type, 'firstchild');
-	pages.forEach(function(page) {
-		assert.strictEqual(menu[root + '/' + page].action.type, 'view');
-		assert.strictEqual(menu[root + '/' + page].action.path, 'xray-mitm/overview');
+	assert.deepStrictEqual(Object.keys(menu), [ root ]);
+	assert.strictEqual(menu[root].action.type, 'view');
+	assert.strictEqual(menu[root].action.path, 'xray-mitm/overview');
+}
+
+function testClientSideDashboardTabs() {
+	function node(attributes) {
+		return {
+			attributes: attributes || {},
+			style: {},
+			className: '',
+			getAttribute: function(name) { return this.attributes[name]; }
+		};
+	}
+
+	const simple = node();
+	const advanced = node();
+	const panels = [
+		node({ 'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'overview' }),
+		node({ 'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'routing' }),
+		node({ 'data-dashboard-panel-mode': 'advanced', 'data-dashboard-panel-page': 'overview' }),
+		node({ 'data-dashboard-panel-mode': 'advanced', 'data-dashboard-panel-page': 'service' })
+	];
+	const rows = [
+		node({ 'data-dashboard-tabs': 'mode' }),
+		node({ 'data-dashboard-tabs': 'basic' }),
+		node({ 'data-dashboard-tabs': 'advanced' })
+	];
+	const tabs = [
+		node({ 'data-dashboard-tab-mode': 'mode', 'data-dashboard-tab-page': 'basic' }),
+		node({ 'data-dashboard-tab-mode': 'mode', 'data-dashboard-tab-page': 'advanced' }),
+		node({ 'data-dashboard-tab-mode': 'basic', 'data-dashboard-tab-page': 'overview' }),
+		node({ 'data-dashboard-tab-mode': 'advanced', 'data-dashboard-tab-page': 'service' })
+	];
+	const fakeDocument = {
+		createTextNode: function(value) { return value; },
+		getElementById: function(id) {
+			return id === 'xray-mitm-simple' ? simple :
+				(id === 'xray-mitm-advanced' ? advanced : null);
+		},
+		querySelectorAll: function(selector) {
+			return selector === '[data-dashboard-panel-mode]' ? panels :
+				(selector === '[data-dashboard-tabs]' ? rows : tabs);
+		}
+	};
+	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
+	const overview = loadLuciModule(overviewSource, {
+		view: { extend: function(methods) { return methods; } },
+		rpc: { declare: function() { return function() {}; } },
+		ui: { addNotification: function() {}, createHandlerFn: function() { return function() {}; } },
+		dom: { content: function() {} },
+		'xray-mitm.state': {}
+	}, {
+		E: function() {},
+		_: function(value) { return value; },
+		document: fakeDocument,
+		L: { bind: function(fn, context) { return fn.bind(context); } }
 	});
+
+	overview.switchDashboardPage('mode', 'advanced');
+	assert.strictEqual(simple.style.display, 'none');
+	assert.strictEqual(advanced.style.display, '');
+	assert.strictEqual(rows[1].style.display, 'none');
+	assert.strictEqual(rows[2].style.display, '');
+	assert.strictEqual(panels[2].style.display, '');
+	assert.strictEqual(tabs[1].className, 'cbi-tab');
+
+	overview.switchDashboardPage('advanced', 'service');
+	assert.strictEqual(panels[2].style.display, 'none');
+	assert.strictEqual(panels[3].style.display, '');
+	assert.strictEqual(tabs[3].className, 'cbi-tab');
 }
 
 testPasswallSelection();
@@ -197,5 +256,6 @@ testSimpleState();
 testRoutingArguments();
 testRouteStatusAndProgress();
 testOverviewLoadsAndRendersWithLuCIStateDependency();
-testRoutedPageMenu();
+testSingleViewMenu();
+testClientSideDashboardTabs();
 console.log('Frontend state tests passed.');


### PR DESCRIPTION
## What changed

The Basic and Advanced dashboards placed every section on one long page. Their section buttons only scrolled within that page, which exposed too much information at once and made navigation harder for new users.

This change gives each section its own LuCI URL and adds familiar PassWall-style tab rows:

- Basic: Overview, Setup, Routing, Status
- Advanced: Overview, Service, Certificates, Routing

Only the selected section is shown. Existing RPC calls, controls, certificate behavior, service behavior, and PassWall2 transaction behavior are preserved.

## Validation

- [x] Complete `sh scripts/validate-release.sh` suite passed locally.
- [x] Frontend state tests verify the routed menu and page selection.
- [x] `git diff --check` passed.
- [x] Exact candidate was staged on the AX4200 with a protected rollback backup.
- [x] All eight pages rendered their expected content with the correct active tab pair and URL.
- [x] Basic/Advanced and subsection navigation was exercised by clicking the tabs.
- [x] No LuCI error notifications or new browser-console errors appeared.
- [x] MITM remained stopped; existing CA material and PassWall2 routing were preserved.
- [x] No private keys, credentials, router configurations, backups, or generated packages are included.
