### PR TITLE
Docs/refresh readme v0.4.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,8 @@ Describe the concrete problem and resulting behavior.
 - [ ] Every affected LuCI page was loaded and exercised in a local browser against
       the lab router, with no error notification, blank view, or new console error;
       or this change cannot affect LuCI.
+- [ ] The project owner visually reviewed and explicitly approved the exact tested
+      UI candidate, or this change cannot affect the UI.
 - [ ] Existing CA material, service state, and PassWall2 routing were preserved unless intentionally changed.
 - [ ] No private keys, credentials, router configurations, backups, or generated packages are included.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Replace the long Basic and Advanced dashboards with native LuCI routed tabs.
+  Each tab now has its own URL and renders only its relevant section.
+
 ### Fixed
 
 - Load the dashboard state helper through LuCI's dependency-injection directive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Replace the long Basic and Advanced dashboards with native LuCI routed tabs.
-  Each tab now has its own URL and renders only its relevant section.
+- Replace the long Basic and Advanced dashboards with PassWall2-style tabs.
+  Switching tabs is immediate and shows only the selected section without
+  reloading the LuCI page.
+- Add a shared PassWall2-style status strip to both Basic and Advanced Overview,
+  showing MITM, PassWall2 routing, and certificate readiness at a glance.
+- Show the application version beside the dashboard title for easier support and
+  update checks.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ a real local-browser test against the lab router before it is pushed:
 Static validation and GitHub Actions do not replace this browser test. Do not push,
 merge, tag, or publish a LuCI change when the real page has not passed it.
 
+After the browser test passes, show the exact tested UI candidate to the project
+owner and obtain explicit visual approval. Do not push, merge, tag, or publish a
+UI-affecting change until that approval is recorded; passing tests or silence do
+not count as approval.
+
 Verify the affected behavior, update from the prior signed version, rollback when
 relevant, and reboot when startup persistence is in scope. Follow
 `docs/RELEASE_TESTING.md` for a public release.

--- a/README.fa.md
+++ b/README.fa.md
@@ -1,21 +1,36 @@
-# راه‌اندازی Xray MITM Domain Fronting روی OpenWrt
+# Xray MITM Domain Fronting برای OpenWrt
 
-**راهنما:** [English](README.md) | فارسی
+**نسخه:** `v0.4.2` · **راهنما:** [English](README.md) | فارسی · **پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
 
-**پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
+این پروژه سرویس مستقل Xray MITM-DomainFronting، داشبورد LuCI و مسیریابی اختیاری PassWall2 را برای روترهای رسمی OpenWrt 25.12 که از APK استفاده می‌کنند فراهم می‌کند.
 
-این پروژه سرویس مستقل Xray MITM-DomainFronting، صفحه مدیریتی LuCI و اتصال اختیاری به مسیریابی PassWall2 را برای OpenWrt رسمی سری 25.12 فراهم می‌کند.
+برای بیشتر کاربران:
+
+1. با یک دستور نصب یا به‌روزرسانی کنید.
+2. در LuCI به **Services → MITM Domain Fronting** بروید.
+3. در بخش **Basic** گزینه **Set up automatically** را انتخاب کنید.
+4. گواهی عمومی را دانلود و مورد اعتماد کنید.
+5. VPN موجود را انتخاب و مسیریابی پیشنهادی را بررسی کنید.
+6. مسیریابی را اعمال و **Run check** را اجرا کنید.
 
 > [!CAUTION]
-> CA مورد اعتماد MITM می‌تواند ترافیک HTTPS دستگاه‌هایی را که به آن اعتماد دارند رمزگشایی کند. فقط روی شبکه و دستگاه‌هایی استفاده کنید که مالک آن‌ها هستید یا اجازه مدیریتشان را دارید. فقط `mycert.crt` را روی کلاینت نصب کنید. `mycert.key` باید روی روتر و در نسخه پشتیبان محافظت‌شده بماند.
+> نرم‌افزار MITM می‌تواند ترافیک HTTPS دستگاه‌هایی را که به گواهی آن اعتماد دارند رمزگشایی کند. فقط در شبکه و دستگاه‌هایی استفاده کنید که مالک آن‌ها هستید یا اجازه مدیریتشان را دارید. فقط `mycert.crt` را روی کلاینت نصب کنید. `mycert.key` باید روی روتر و در نسخه‌های پشتیبان محافظت‌شده باقی بماند.
 
-## از اینجا شروع کنید
+## نیازمندی‌ها
 
-feed عمومی فعلی برای OpenWrt رسمی **نسخه 25.12.5 و نسخه‌های نگهداری جدیدتر از سری 25.12** است. روتر باید از مدیر بسته `apk` استفاده کند و به GitHub و GitHub Pages دسترسی داشته باشد.
+- OpenWrt رسمی 25.12.5 یا یکی از نسخه‌های نگهداری بعدی سری 25.12، همراه با `apk` و LuCI.
+- دسترسی روتر به GitHub و GitHub Pages.
+- PassWall2 برای مسیریابی خودکار؛ خود سرویس MITM به PassWall2 نیاز ندارد.
+- یک پروفایل shunt فعال و یک VPN سالم در PassWall2 برای سرویس‌هایی که باید از VPN عبور کنند.
 
-### ۱. نصب یا به‌روزرسانی با یک دستور
+## سازگاری
 
-اگر آدرس روتر متفاوت است، `192.168.1.1` را تغییر دهید. وقتی درخواست شد رمز روتر را وارد کنید.
+- OpenWrt رسمی 25.12.x با بسته‌های APK: `xray-mitm` و `luci-app-xray-mitm`.
+- سخت‌افزار آزمایش‌شده: ASUS TUF-AX4200. سخت‌افزارهای دیگر ممکن است کار کنند، اما در فهرست آزمایش‌شده نیستند.
+
+## نصب یا به‌روزرسانی
+
+همین دستور برای نصب اولیه و به‌روزرسانی‌های بعدی استفاده می‌شود. اگر آدرس روتر متفاوت است، `192.168.1.1` را تغییر دهید.
 
 **MAC:**
 
@@ -29,7 +44,7 @@ ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.
 ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
-اگر از قبل با SSH داخل روتر هستید:
+اگر از قبل داخل SSH روتر هستید:
 
 **ROUTER:**
 
@@ -37,242 +52,90 @@ ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.git
 wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-دستور، فایل نصب‌کننده عمومی را پیش از اجرا بررسی می‌کند. SHA-256 ثابت آن `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405` است.
+نصب‌کننده نسخه OpenWrt، checksum نصب‌کننده و feed امضاشده را بررسی می‌کند، نسخه پشتیبان محافظت‌شده می‌سازد و فقط بسته‌های پروژه را نصب یا به‌روزرسانی می‌کند. PassWall2 نصب نمی‌شود، گواهی ساخته نمی‌شود، MITM روشن نمی‌شود و مسیریابی تغییر نمی‌کند.
 
-همین دستور هم نصب اولیه و هم به‌روزرسانی‌های بعدی را انجام می‌دهد. نصب‌کننده:
+SHA-256 ثابت نصب‌کننده این است: `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
 
-1. نسخه OpenWrt و مدیر بسته را بررسی می‌کند.
-2. کلید عمومی feed را با HTTPS دریافت می‌کند.
-3. فقط در صورت تطبیق دقیق fingerprint زیر، کلید را می‌پذیرد:
+بعد از پایان، LuCI را با **HTTPS** در مسیر **Services → MITM Domain Fronting** باز کنید.
 
-   ```text
-   3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
-   ```
+## راه‌اندازی اولیه
 
-4. feed امضاشده را به APK اضافه و فایل‌های آن را برای ارتقای firmware نگه می‌دارد.
-5. داخل `/root/` یک نسخه پشتیبان محافظت‌شده می‌سازد.
-6. از APK می‌خواهد امضا را بررسی و فقط بسته‌های `xray-mitm` و `luci-app-xray-mitm` را نصب یا به‌روزرسانی کند.
+این روند برای نصب تازه است. به‌روزرسانی تنظیمات، گواهی فعال، وضعیت سرویس و مسیریابی PassWall2 را حفظ می‌کند؛ فقط اگر LuCI چیزی را ناقص اعلام کرد راه‌اندازی را تکرار کنید.
 
-نصب‌کننده از `--allow-untrusted` استفاده نمی‌کند، همه بسته‌های روتر را یک‌جا ارتقا نمی‌دهد، CA نمی‌سازد، سرویس را روشن نمی‌کند و مسیریابی PassWall2 را تغییر نمی‌دهد.
+### ۱. آماده‌سازی روتر
 
-### ۲. راه‌اندازی اولیه در LuCI
+در **Basic → Setup** گزینه **Set up automatically** را انتخاب کنید.
 
-LuCI را با **HTTPS** باز کنید و به **Services → MITM Domain Fronting** بروید.
+این گزینه پیکربندی پیش‌فرض را در صورت نیاز آماده می‌کند، گواهی را در صورت نیاز می‌سازد و فعال می‌کند، MITM را روشن می‌کند و شروع خودکار بعد از راه‌اندازی مجدد را فعال می‌کند. پیکربندی و گواهی معتبر موجود را حفظ می‌کند و PassWall2 را نصب نمی‌کند.
 
-این بخش فقط برای نصب تازه است. اگر در حال به‌روزرسانی نصب موجود هستید،
-این بخش را تکرار نکنید؛ به‌روزرسانی تنظیمات، CA فعال، وضعیت سرویس و مسیریابی
-PassWall2 را حفظ می‌کند. در این حالت راهنما به‌جای **First-time setup**،
-**System overview** را نشان می‌دهد و فقط موارد ناقص را درخواست می‌کند.
+### ۲. دانلود و اعتماد به گواهی عمومی
 
-برای مسیر ساده، در نمای **Simple** گزینه **Set up automatically** را انتخاب
-کنید. این گزینه در صورت نیاز پیکربندی بسته را نصب می‌کند، در صورت نیاز CA را
-می‌سازد و فعال می‌کند، MITM را روشن می‌کند و شروع خودکار پس از راه‌اندازی را
-فعال می‌کند. پیکربندی یا CA معتبر موجود را جایگزین نمی‌کند.
+در **Basic → Setup** گزینه **Download public certificate** را انتخاب کنید. فقط `mycert.crt` را روی دستگاه‌هایی نصب کنید که باید از MITM استفاده کنند؛ کلید خصوصی روی روتر باقی می‌ماند.
 
-بعد از راه‌اندازی خودکار:
+- **macOS:** گواهی را باز کنید، به Keychain Access اضافه کنید و **Always Trust** را فعال کنید.
+- **Windows:** گواهی را باز کنید، **Install Certificate** را بزنید و آن را در **Trusted Root Certification Authorities** قرار دهید.
+- **Android:** تنظیمات Security را باز کنید، **Install a certificate** را انتخاب کنید و آن را به‌عنوان CA certificate نصب کنید.
 
-1. فقط `mycert.crt` را دانلود کنید.
-2. `mycert.crt` را روی کلاینت‌هایی که باید از MITM استفاده کنند به‌عنوان Root CA مورد اعتماد نصب کنید.
-3. Health check را اجرا کنید و مطمئن شوید نتیجه PASS است.
-4. اگر مسیریابی انتخابی لازم دارید، به بخش PassWall2 در پایین بروید.
+نام منوها ممکن است در نسخه‌های مختلف سیستم‌عامل فرق کند. Firefox ممکن است از مخزن گواهی جداگانه استفاده کند. بعضی برنامه‌های native به گواهی نصب‌شده توسط کاربر اعتماد نمی‌کنند یا certificate pinning دارند؛ ابتدا مرورگر را آزمایش کنید.
 
-اگر نمای **Advanced settings** را انتخاب کردید، ترتیب دستی معادل این است:
-نصب پیکربندی پیش‌فرض، ساختن یا وارد کردن گواهی و کلید خصوصی منطبق به‌عنوان
-candidate، فعال‌کردن candidate، روشن‌کردن سرویس، اجرای health check و فعال‌کردن
-شروع خودکار. `mycert.key` را هرگز روی کلاینت کپی نکنید.
+### ۳. تنظیم مسیریابی پیشنهادی
 
-CA عمومی را برای کاربر فعلی نصب کنید:
+اگر به مسیریابی PassWall2 نیاز ندارید، این مرحله را رد کنید. در غیر این صورت به **Basic → Routing** بروید و این موارد را انتخاب کنید:
 
-**MAC:**
+- **Main routing profile** — پروفایل shunt که در PassWall2 فعال است.
+- **Working VPN connection** — یک VPN موجود که از قبل کار می‌کند.
 
-```sh
-security add-trusted-cert -r trustRoot \
-  -k "$HOME/Library/Keychains/login.keychain-db" ./mycert.crt
-```
+گزینه **Review selected routing** را بزنید، مقصدها را بررسی کنید و سپس **Apply recommended routing** را انتخاب کنید. مقصدهای MITM به سرویس روشن نیاز دارند؛ در صورت نیاز آن را از **Advanced → Service** روشن کنید. دستیار preview را بررسی و قوانین نامرتبط PassWall2 را حفظ می‌کند.
 
-**WINDOWS PC (PowerShell):**
+### ۴. بررسی عملکرد
 
-```powershell
-certutil.exe -user -addstore -f Root .\mycert.crt
-```
+به **Basic → Status** بروید و **Run check** را انتخاب کنید. این بررسی سرویس MITM روی روتر را آزمایش می‌کند و ثابت نمی‌کند که همه کلاینت‌ها به `mycert.crt` اعتماد دارند.
 
-ممکن است Firefox از certificate store جدا استفاده کند؛ در این حالت `mycert.crt` را داخل Firefox هم وارد کنید. `mycert.key` را هرگز روی کلاینت کپی نکنید.
+بعد از موفقیت، وب‌سایت‌ها را با مرورگر کلاینت آزمایش کنید. سایت MITM باید `MITM-DomainFronting` را به‌عنوان issuer نشان دهد؛ سایت VPN یا direct باید مرجع گواهی عمومی عادی خود را نشان دهد.
 
-### ۳. مسیریابی دامنه‌های انتخابی با PassWall2
+## مسیریابی پیشنهادی
 
-اگر فقط SOCKS محلی را می‌خواهید، این مرحله را رد کنید.
+مدل پیش‌فرض بر اساس هدف ترافیک است:
 
-1. بخش PassWall2 را در صفحه LuCI پروژه باز کنید.
-2. shunt node و VPN node موجود را انتخاب کنید.
-3. اگر سرویس MITM را انتخاب می‌کنید، مطمئن شوید سرویس در وضعیت running است.
-   دستیار previewای را که ترافیک را به SOCKS محلی متوقف می‌فرستد اجازه نمی‌دهد.
-4. **Review selected routing** یا **Preview changes** را بزنید.
-5. node محلی، دامنه‌ها، مقصدها و ترتیب قوانین را بررسی کنید.
-6. فقط وقتی preview درست است **Apply preview** را انتخاب کنید.
+| ترافیک | مقصد | هدف |
+| --- | --- | --- |
+| سرویس‌های Google | MITM | استفاده از سرویس MITM محلی برای گروه انتخاب‌شده Google. |
+| اپلیکیشن و API جمنای | VPN انتخاب‌شده | عبور ترافیک Gemini از VPN سالم. |
+| وب‌سایت‌ها و IPهای ایران | Direct | عبور مستقیم ترافیک محلی انتخاب‌شده بدون VPN و MITM. |
 
-دستیار حداکثر سه قانون مدیریت‌شده می‌سازد و آن‌ها را به این ترتیب قرار می‌دهد:
+گروه‌های اختیاری در **Basic → Routing** قرار دارند:
 
-1. **VPN Overrides** بسته‌های انتخابی Gemini، بررسی اتصال Android، کنترل YouTube و ورود Google Account را به VPN انتخاب‌شده می‌فرستد. دامنه تحویل ویدئو یعنی `googlevideo.com` عمداً در این قانون نیست.
-2. **MITM-Compatible Services** بسته‌های انتخابی Google، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را به SOCKS محلی `127.0.0.1:10808` می‌فرستد. Google پیشنهاد پیش‌فرض است؛ Meta و Fastly تا زمان آزمایش روی دستگاه‌های شما خاموش می‌مانند.
-3. **Regional Direct Access** دامنه‌ها و IPهای ایران را مستقیم می‌فرستد.
+- **VPN Overrides** می‌تواند بررسی اتصال Android، ورود و کنترل‌های YouTube و ورود به حساب Google را شامل شود. `googlevideo.com` عمداً خارج است تا تحویل ویدئوی YouTube بتواند از MITM استفاده کند.
+- **MITM-Compatible Services** می‌تواند گروه‌های Google، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را شامل شود. ابتدا Google را آزمایش کنید و قبل از اتکا به برنامه‌های native، Meta و Fastly را جداگانه آزمایش کنید.
+- **Regional Direct Access** از گروه‌های دامنه و IP ایران استفاده می‌کند.
 
-هر checkbox فقط یک مجموعه دامنه را به یکی از همین سه قانون اضافه می‌کند و قانون جداگانه‌ای نمی‌سازد. اولین اعمال مدل سه‌قانونی، قوانین قدیمی مدیریت‌شده توسط بسته را مهاجرت می‌دهد. قوانین قدیمی ساخته‌شده توسط کاربر بدون تغییر باقی می‌مانند، ولی اتصال آن‌ها به shunt انتخابی حذف می‌شود تا تطبیق تکراری رخ ندهد. برای جلوگیری از loop، مقدار `localhost_proxy=0` را نگه دارید.
+هر checkbox یک گروه سرویس را داخل یکی از این انتساب‌ها فعال می‌کند و قانون جداگانه نمی‌سازد. بیشتر کاربران می‌توانند انتخاب‌های پیشنهادی را بدون تغییر نگه دارند.
 
-### ۴. بررسی از دستگاه کلاینت
+## به‌روزرسانی
 
-**MAC:**
+همان دستور نصب را دوباره اجرا کنید. به‌روزرسانی تنظیمات، گواهی فعال، وضعیت سرویس و مسیریابی PassWall2 را حفظ می‌کند. سپس LuCI را reload کنید و کارت‌های وضعیت را ببینید؛ تا وقتی LuCI درخواست نکرده گواهی جدید نسازید یا راه‌اندازی اولیه را تکرار نکنید.
 
-```sh
-for url in \
-  https://www.google.com \
-  https://www.youtube.com \
-  https://www.cloudflare.com \
-  https://gemini.google.com
-do
-  printf '\n%s\n' "$url"
-  curl -Iv --max-time 20 "$url" 2>&1 |
-    grep -E 'issuer:|^HTTP/'
-done
-```
+## مشکلات رایج
 
-**WINDOWS PC (PowerShell):**
+- **PassWall2 شناسایی نمی‌شود:** MITM می‌تواند اجرا شود، اما مسیریابی خودکار به PassWall2 نیاز دارد. آن را نصب و فعال کنید و LuCI را reload کنید.
+- **VPN یا پروفایل مسیریابی پیدا نشد:** یک VPN یا پروفایل shunt سالم در PassWall2 بسازید و به **Basic → Routing** برگردید.
+- **مسیرهای MITM کار نمی‌کنند:** در **Advanced → Service** روشن بودن MITM و اعتماد کلاینت به `mycert.crt` را بررسی کنید.
+- **خطای certificate:** فقط `mycert.crt` فعلی را نصب کنید و هرگز `mycert.key` را کپی نکنید؛ وضعیت گواهی را در **Advanced → Certificates** بررسی کنید.
+- **برنامه native کار نمی‌کند:** بعضی برنامه‌ها CA کاربر را نمی‌پذیرند، certificate pinning دارند یا خارج از گروه انتخاب‌شده کار می‌کنند. ابتدا مرورگر را بررسی کنید.
 
-```powershell
-$urls = @(
-  'https://www.google.com',
-  'https://www.youtube.com',
-  'https://www.cloudflare.com',
-  'https://gemini.google.com'
-)
+## بخش Advanced
 
-foreach ($url in $urls) {
-  Write-Host "`n$url"
-  curl.exe -Iv --max-time 20 $url 2>&1 |
-    Select-String -Pattern 'issuer:', 'HTTP/'
-}
-```
+بیشتر کاربران به مرجع فنی نیاز ندارند. جزئیات چرخه گواهی، کنترل دستی سرویس، مسیریابی سفارشی، rollback، recovery، SOCKS محلی و فرمان‌های CLI در این فایل‌هاست:
 
-دامنه‌ای که از MITM عبور می‌کند باید این issuer را نشان دهد:
-
-```text
-issuer: CN=MITM-DomainFronting
-```
-
-دامنه‌های VPN یا direct باید CA عمومی عادی خود را نشان دهند. پاسخ HTTP دامنه‌های مورد انتظار نیز باید موفق باشد.
-
-## به‌روزرسانی‌های بعدی
-
-ساده‌ترین روش، اجرای دوباره همان دستور نصب یک‌خطی است. بعد از تنظیم feed می‌توانید مستقیماً روی روتر نیز به‌روزرسانی کنید:
-
-**ROUTER:**
-
-```sh
-apk update
-apk upgrade xray-mitm luci-app-xray-mitm
-```
-
-این دستور فقط همین دو بسته انتخاب‌شده و وابستگی‌های لازم آن‌ها را ارتقا می‌دهد. از اجرای `apk upgrade` بدون نام بسته‌ها به‌عنوان جایگزین ارتقای firmware استفاده نکنید.
-
-به‌روزرسانی، `/etc/config/xray-mitm`، پوشه `/etc/xray-mitm/`، CA فعال، وضعیت سرویس و تنظیمات PassWall2 را حفظ می‌کند. قبل از تغییر feed یا بسته‌ها، نصب‌کننده فایل پشتیبان `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` را با سطح دسترسی `0600` می‌سازد.
-
-بعد از به‌روزرسانی، LuCI را دوباره بارگذاری و کارت‌های وضعیت را بررسی کنید.
-ساختن CA جدید یا اجرای دوباره راه‌اندازی اولیه لازم نیست، مگر اینکه صفحه
-اعلام کند پیکربندی یا وضعیت گواهی وجود ندارد یا نیاز به بررسی دارد.
-
-## روش احراز اصالت
-
-در اجرای اول، نصب‌کننده با HTTPS از GitHub دریافت می‌شود و fingerprint کلید عمومی feed را در خود دارد. APK با این کلید، امضای index و همه بسته‌ها را بررسی می‌کند. به‌روزرسانی‌های بعدی نیز از همان کلید ذخیره‌شده و feed امضاشده استفاده می‌کنند.
-
-- build عادی pull request هیچ secretی ندارد و فقط artifact توسعه‌ای بدون کلید امضای production و بدون secret می‌سازد.
-- tag انتشار باید دقیقاً با نسخه بسته یکی باشد.
-- امضای production فقط در GitHub environment محافظت‌شده `signed-feed` انجام می‌شود.
-- workflow ابتدا تطبیق کلید خصوصی محافظت‌شده با کلید عمومی commit‌شده را بررسی می‌کند.
-- SDK رسمی OpenWrt فایل `packages.adb` و APKهای امضاشده را می‌سازد.
-- feed در GitHub Pages و فایل‌های همان نسخه در GitHub Release منتشر می‌شوند.
-
-کلید خصوصی production داخل repository یا package قرار نمی‌گیرد. جزئیات انتشار، بازیابی و تعویض کلید در [راهنمای عملیات feed امضاشده](docs/SIGNED_FEED.md) آمده است.
-
-## نیازمندی‌ها و رفتار امن
-
-بسته‌ها `all` هستند، ولی feed فعلی برای اکوسیستم APK در OpenWrt 25.12 آزمایش می‌شود. نصب اولیه عمداً غیرفعال است: CA ساخته نمی‌شود، startup فعال نمی‌شود، Xray اجرا نمی‌شود و firewall، DNS و PassWall2 تغییر نمی‌کنند.
-
-listenerها فقط روی localhost هستند:
-
-| کاربرد | آدرس |
-| --- | --- |
-| ورودی محلی mixed/SOCKS | `127.0.0.1:10808` |
-| تونل رمزگشایی TLS برای HTTP/1.1 | `127.0.0.1:11666` |
-| تونل رمزگشایی TLS برای HTTP/2 | `127.0.0.1:11777` |
-
-## نصب دستی احرازشده
-
-اگر روتر به GitHub Pages دسترسی ندارد، دو APK، فایل `xray-mitm-feed-v1.pem`، فایل `PUBLIC_KEY_SHA256` و `SHA256SUMS` را از یک GitHub Release امضاشده واحد روی مک یا ویندوز دریافت کنید.
-
-**ROUTER:**
-
-```sh
-mkdir -p -m 0700 /tmp/xray-mitm-install
-```
-
-**MAC:**
-
-```sh
-cd "/path/to/downloaded/release-files"
-scp -O xray-mitm-*.apk luci-app-xray-mitm-*.apk \
-  xray-mitm-feed-v1.pem PUBLIC_KEY_SHA256 SHA256SUMS \
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-**WINDOWS PC (PowerShell):**
-
-```powershell
-Set-Location "C:\path\to\downloaded\release-files"
-scp.exe -O .\xray-mitm-*.apk .\luci-app-xray-mitm-*.apk `
-  .\xray-mitm-feed-v1.pem .\PUBLIC_KEY_SHA256 .\SHA256SUMS `
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-قبل از نصب کلید، fingerprint را با مقدار این README مقایسه کنید. اگر متفاوت بود ادامه ندهید.
-
-**ROUTER:**
-
-```sh
-cd /tmp/xray-mitm-install
-printf '%s  %s\n' \
-  '3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a' \
-  'xray-mitm-feed-v1.pem' | sha256sum -c -
-awk '$2 ~ /[.]apk$/' SHA256SUMS | sha256sum -c -
-mkdir -p /etc/apk/keys
-cp xray-mitm-feed-v1.pem /etc/apk/keys/xray-mitm-feed-v1.pem
-chmod 0644 /etc/apk/keys/xray-mitm-feed-v1.pem
-apk add ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
-```
-
-artifactهای توسعه‌ای CI خارج از مسیر اعتماد production هستند و نباید به‌عنوان انتشار امضاشده به کاربر تازه‌کار داده شوند.
-
-## آزمایش توسعه و انتشار
-
-برای روند branch محلی و pull request، [راهنمای مشارکت](CONTRIBUTING.md) و برای
-تاریخچه تغییرات قابل مشاهده کاربران، [فهرست تغییرات](CHANGELOG.md) را ببینید.
-
-**MAC:**
-
-```sh
-cd "/path/to/xray-mitm-openwrt"
-sh scripts/validate-release.sh
-```
-
-**WINDOWS PC (PowerShell with WSL):**
-
-```powershell
-wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
-```
-
-قبل از انتشار tag، [راهنمای آزمایش انتشار](docs/RELEASE_TESTING.md) را اجرا کنید.
+- [راهنمای پیشرفته](docs/ADVANCED.md)
+- [امنیت](SECURITY.md)
+- [عملیات feed امضاشده](docs/SIGNED_FEED.md)
+- [آزمایش انتشار](docs/RELEASE_TESTING.md)
+- [روند مشارکت و توسعه](CONTRIBUTING.md)
 
 ## حذف
 
-ابتدا سرویس را متوقف و startup را غیرفعال کنید. اگر مسیریابی PassWall2 اعمال شده، rollback را از LuCI اجرا کنید. سپس:
+اگر مسیریابی اعمال شده است، ابتدا آن را از LuCI rollback کنید. سپس روی روتر:
 
 **ROUTER:**
 
@@ -282,6 +145,8 @@ wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
 apk del luci-app-xray-mitm xray-mitm
 ```
 
-بعد از پایان استفاده، `mycert.crt` را از trust store همه کلاینت‌ها حذف کنید. `mycert.key` و نسخه‌های پشتیبان روتر همچنان محرمانه هستند.
+بعد از پایان استفاده، `mycert.crt` را از trust store کلاینت‌ها حذف کنید. نسخه‌های پشتیبان و `mycert.key` همچنان محرمانه هستند.
 
-این پروژه مستقل از Xray-core، OpenWrt، LuCI و PassWall2 است. مجوزها و attribution در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) آمده است.
+## انتساب
+
+پیکربندی domain-fronting بسته از [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23) گرفته شده و تحت مجوز GPL-3.0 است. Xray-core، OpenWrt، LuCI و PassWall2 پروژه‌های upstream جداگانه هستند. به [اعلان‌های third-party](THIRD_PARTY_NOTICES.md) مراجعه کنید.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,36 @@
 # Xray MITM Domain Fronting for OpenWrt
 
-**Instructions:** English | [فارسی](README.fa.md)
+**Version:** `v0.4.2` · **Instructions:** English | [فارسی](README.fa.md) · **Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
 
-**Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
+This project adds a standalone Xray MITM-DomainFronting service, a LuCI dashboard, and optional PassWall2 routing to official OpenWrt 25.12 APK-based routers.
 
-This project packages a standalone Xray MITM-DomainFronting service, a LuCI management page, and optional PassWall2 routing for official OpenWrt 25.12 APK-based routers.
+For most users:
+
+1. Install or update with one command.
+2. Open LuCI and go to **Services → MITM Domain Fronting**.
+3. In **Basic**, select **Set up automatically**.
+4. Download and trust the public certificate.
+5. Choose your existing VPN and review the recommended routing.
+6. Apply the routing and select **Run check**.
 
 > [!CAUTION]
-> A trusted MITM certificate authority can decrypt HTTPS traffic from devices that trust it. Use it only on networks and devices you own or are authorized to manage. Install only `mycert.crt` on clients. Keep `mycert.key` on the router and in protected backups.
+> MITM software can decrypt HTTPS traffic from devices that trust its certificate. Use it only on networks and devices you own or are authorized to manage. Install only `mycert.crt` on clients. Keep `mycert.key` on the router and in protected backups.
 
-## Start here
+## Requirements
 
-The supported public feed currently targets official OpenWrt **25.12.5 and later 25.12 maintenance releases**. The router must use the `apk` package manager and have internet access to GitHub and GitHub Pages.
+- Official OpenWrt 25.12.5 or a later 25.12 maintenance release, with `apk` and LuCI.
+- Internet access from the router to GitHub and GitHub Pages.
+- PassWall2 for automatic routing. It is not required for the MITM service itself.
+- A working PassWall2 shunt profile and VPN node for VPN-routed services.
 
-### 1. Install or update with one command
+## Compatibility
 
-Replace `192.168.1.1` if your router uses another address. Enter the router password when asked.
+- Official OpenWrt 25.12.x using APK packages: `xray-mitm` and `luci-app-xray-mitm`.
+- Tested hardware: ASUS TUF-AX4200. Other hardware may work, but is not on the tested list.
+
+## Install or update
+
+The same command is used for a first installation and later updates. Replace `192.168.1.1` if your router uses another address.
 
 **MAC:**
 
@@ -29,256 +44,96 @@ ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.
 ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
-If you are already connected through SSH:
-
-**ROUTER:**
+**ROUTER** if you are already connected through SSH:
 
 ```sh
 wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-The command verifies the public installer before running it. Its pinned SHA-256 is `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
+The installer checks the OpenWrt release, verifies the installer checksum and signed feed, creates a protected backup, and updates only the project packages. It does not install PassWall2, create a certificate, start MITM, or change routing.
 
-The same command handles first installation and later updates. It:
+The pinned installer SHA-256 is `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
 
-1. Checks the OpenWrt release and package manager.
-2. Downloads the project feed public key over HTTPS.
-3. Requires this exact SHA-256 fingerprint before trusting the key:
+When it finishes, open LuCI over **HTTPS** at **Services → MITM Domain Fronting**.
 
-   ```text
-   3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
-   ```
+## First-time setup
 
-4. Adds the signed feed to APK and preserves the feed configuration across firmware upgrades.
-5. Makes a protected backup under `/root/`.
-6. Lets APK verify and install or update `xray-mitm` and `luci-app-xray-mitm` by package name.
+This flow is for a fresh installation. Updates preserve the configuration, active certificate, service state, and PassWall2 routing; repeat setup only if LuCI reports that something is missing.
 
-The installer never uses `--allow-untrusted`, never upgrades every package on the router, and does not create a CA, start the service, or change PassWall2 routing.
+### 1. Set up the router
 
-### 2. Complete first-time setup in LuCI
+In **Basic → Setup**, select **Set up automatically**.
 
-Open LuCI over **HTTPS**, then go to **Services → MITM Domain Fronting**.
+This prepares the default configuration when needed, creates and activates a certificate when needed, starts MITM, and enables startup after reboot. It preserves a valid existing configuration and certificate and does not install PassWall2.
 
-This section is for a new installation. If you are updating an existing
-installation, skip it: updates preserve the configuration, active CA, service
-state, and PassWall2 routing. The setup guide will show **System overview**
-and only ask you to complete items that are not ready.
+### 2. Download and trust the public certificate
 
-For the beginner path, stay in **Simple** view and select **Set up
-automatically**. It installs the packaged configuration when needed,
-generates and activates a CA when needed, starts MITM, and enables automatic
-startup. It does not replace an existing valid configuration or CA.
+In **Basic → Setup**, select **Download public certificate**. Install only `mycert.crt` on devices that should use MITM; the private key stays on the router.
 
-After automatic setup:
+- **macOS:** open it, add it to Keychain Access, and set it to **Always Trust**.
+- **Windows:** open it, select **Install Certificate**, and place it in **Trusted Root Certification Authorities**.
+- **Android:** open Security settings, choose **Install a certificate**, and install it as a CA certificate.
 
-1. Download only `mycert.crt`.
-2. Install `mycert.crt` as a trusted root on each client that should use MITM.
-3. Run the health check and confirm it passes.
-4. Continue to PassWall2 routing below if you need selective routing.
+Menu names can vary by operating-system version. Firefox may use a separate certificate store. Some native applications ignore user-installed certificates or use certificate pinning; test a browser first.
 
-If you choose **Advanced settings** instead, the equivalent manual sequence
-is: install the packaged default configuration, generate or import a matching
-certificate and private key as a candidate, activate the candidate, start the
-service, run the health check, and enable automatic startup. Never copy
-`mycert.key` to a client.
+### 3. Configure recommended routing
 
-Trust the downloaded public CA for your current user:
+If you do not need PassWall2 routing, skip this step. Otherwise open **Basic → Routing** and choose:
 
-**MAC:**
+- **Main routing profile** — the shunt profile already active in PassWall2.
+- **Working VPN connection** — an existing VPN node that already works.
 
-```sh
-security add-trusted-cert -r trustRoot \
-  -k "$HOME/Library/Keychains/login.keychain-db" ./mycert.crt
-```
+Select **Review selected routing**, inspect the destinations, and then select **Apply recommended routing**. MITM-compatible routes require the service to be running; start it in **Advanced → Service** if necessary. The assistant validates the preview and preserves unrelated PassWall2 rules.
 
-**WINDOWS PC (PowerShell):**
+### 4. Check that it works
 
-```powershell
-certutil.exe -user -addstore -f Root .\mycert.crt
-```
+Open **Basic → Status** and select **Run check**. This verifies the router-side MITM service. It does not prove that every client trusts `mycert.crt`.
 
-Firefox may use its own certificate store. If it does, import `mycert.crt` inside Firefox too. Never copy `mycert.key` to a client.
+After it passes, test the intended websites from a client browser. A site using MITM should show `MITM-DomainFronting` as its certificate issuer; a VPN-routed or direct site should show its normal public certificate authority.
 
-### 3. Route selected domains through PassWall2
+## Recommended routing
 
-Skip this step if you only need the local SOCKS service.
+The default model is based on traffic purpose:
 
-1. Open the PassWall2 section on the project’s LuCI page.
-2. Choose the existing shunt node and VPN node.
-3. If you select any MITM-compatible service, confirm that the MITM service
-   is running. The assistant will not allow a preview that would send traffic
-   to a stopped local SOCKS listener.
-4. Select **Review selected routing** or **Preview changes**.
-5. Review the local node, domains, destinations, and rule order.
-6. Select **Apply preview** only after the preview is correct.
+| Traffic | Destination | Purpose |
+| --- | --- | --- |
+| Google services | MITM | Use the local MITM service for the selected Google bundle. |
+| Gemini app and API | Selected VPN | Send Gemini traffic through the working VPN. |
+| Iranian websites and IP addresses | Direct | Avoid the VPN and MITM for selected local traffic. |
 
-The assistant creates at most three package-managed rules, in this order:
+Optional service groups are available in **Basic → Routing**:
 
-1. **VPN Overrides** sends selected Gemini, Android connectivity, YouTube control, and Google Account bundles to the chosen VPN. YouTube video delivery (`googlevideo.com`) is deliberately excluded.
-2. **MITM-Compatible Services** sends selected Google, Meta website, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`. Google is recommended; Meta and Fastly stay off until you test them on your devices.
-3. **Regional Direct Access** sends Iranian domains and IP ranges directly.
+- **VPN Overrides** can include Android connectivity checks, YouTube sign-in and controls, and Google Account sign-in. `googlevideo.com` is excluded so high-speed YouTube video delivery can use MITM.
+- **MITM-Compatible Services** can include Google, Meta, and Fastly-backed website groups. Google is the recommended starting point; test Meta and Fastly before relying on native applications.
+- **Regional Direct Access** uses the packaged Iranian domain and IP groups.
 
-The checkboxes add domain bundles to these three rules; they do not create one rule per checkbox. Applying the first three-rule preview migrates older package-managed rules. Recognized user-created legacy rules remain unchanged, but their assignments are removed from the selected shunt to prevent duplicate matches. Keep `localhost_proxy=0` to prevent the standalone Xray output from looping back into PassWall2.
+Each checkbox enables a service group inside one of these assignments; it does not create a separate rule. Most users can keep the recommended choices unchanged.
 
-### 4. Verify from a client
+## Updating
 
-**MAC:**
+Run the same installation command again. It preserves the configuration, active certificate, service state, and PassWall2 routing. Reload LuCI and review the status cards; do not generate a new certificate or repeat setup unless LuCI asks you to.
 
-```sh
-for url in \
-  https://www.google.com \
-  https://www.youtube.com \
-  https://www.cloudflare.com \
-  https://gemini.google.com
-do
-  printf '\n%s\n' "$url"
-  curl -Iv --max-time 20 "$url" 2>&1 |
-    grep -E 'issuer:|^HTTP/'
-done
-```
+## Common problems
 
-**WINDOWS PC (PowerShell):**
+- **PassWall2 is not detected:** MITM can still run, but automatic routing requires PassWall2. Install and enable it, then reload LuCI.
+- **No VPN or routing profile:** add and test a VPN node or shunt profile in PassWall2, then return to **Basic → Routing**.
+- **MITM routes do not work:** in **Advanced → Service**, confirm that MITM is running and the client trusts `mycert.crt`.
+- **Certificate error:** install only the current `mycert.crt`. Never copy `mycert.key`; review certificate state in **Advanced → Certificates**.
+- **Native app fails:** some apps ignore user-installed CAs, use certificate pinning, or use traffic outside the selected group. Confirm the browser path first.
 
-```powershell
-$urls = @(
-  'https://www.google.com',
-  'https://www.youtube.com',
-  'https://www.cloudflare.com',
-  'https://gemini.google.com'
-)
+## Advanced
 
-foreach ($url in $urls) {
-  Write-Host "`n$url"
-  curl.exe -Iv --max-time 20 $url 2>&1 |
-    Select-String -Pattern 'issuer:', 'HTTP/'
-}
-```
+Most users do not need the technical reference. It covers certificate lifecycle, manual service controls, custom routing, rollback, recovery, local SOCKS details, and CLI commands:
 
-A domain using MITM should show:
+- [Advanced usage](docs/ADVANCED.md)
+- [Security](SECURITY.md)
+- [Signed feed operations](docs/SIGNED_FEED.md)
+- [Release testing](docs/RELEASE_TESTING.md)
+- [Contributing and development workflow](CONTRIBUTING.md)
 
-```text
-issuer: CN=MITM-DomainFronting
-```
+## Remove
 
-A domain using VPN or direct routing should show its normal public certificate authority. All expected requests should return a successful HTTP response.
-
-## Updating later
-
-The easiest update is to run the same one-command installer again. After the feed is configured, you can also update directly:
-
-**ROUTER:**
-
-```sh
-apk update
-apk upgrade xray-mitm luci-app-xray-mitm
-```
-
-This upgrades only these two explicitly selected packages and required dependencies. Do not use an unrestricted `apk upgrade` as a replacement for a planned OpenWrt firmware upgrade.
-
-Updates preserve `/etc/config/xray-mitm`, `/etc/xray-mitm/`, the active CA, service settings, and existing PassWall2 configuration. The installer creates `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` with mode `0600` before changing feed or package state.
-
-After an update, reload LuCI and review the status cards. Do not generate a
-new CA or run first-time setup again unless the page reports that configuration
-or certificate state is missing or needs attention.
-
-## How authentication works
-
-The first one-command run downloads the installer from GitHub over HTTPS. That installer pins the reviewed feed public-key fingerprint shown above. APK then uses the installed public key to authenticate the feed index and every package. Later updates use the same stored key and signed feed.
-
-Production publishing is separate from ordinary pull-request builds:
-
-- Pull requests run offline validation and development artifacts without the production signing key or secrets.
-- A version tag must match the package version exactly.
-- The signing job runs only behind the protected `signed-feed` GitHub environment.
-- The job proves that the protected private key matches the public key committed in `keys/xray-mitm-feed-v1.pem`.
-- OpenWrt’s SDK creates the native signed `packages.adb` index and signed APKs.
-- The workflow publishes the feed through GitHub Pages and keeps the signed files with the matching GitHub Release.
-
-The production private key is never stored in this repository or included in packages. See [Signed feed operations](docs/SIGNED_FEED.md) for publishing, recovery, and key-rotation procedures.
-
-## Requirements and package behavior
-
-The packages are architecture-independent (`all`) but currently require the official OpenWrt 25.12 APK package ecosystem. Dependencies include `xray-core`, `curl`, `openssl-util`, `uci`, `jsonfilter`, `coreutils-stat`, `v2ray-geoip`, and `v2ray-geosite`; LuCI also requires `luci-base`, `rpcd-mod-ucode`, and `ucode-mod-fs`.
-
-The default installation is intentionally inactive. Installing or updating packages does not generate a CA, enable boot startup, start Xray, alter firewall or DNS state, or apply PassWall2 changes. The three Xray listeners remain on localhost:
-
-| Purpose | Address |
-| --- | --- |
-| Local mixed/SOCKS entry | `127.0.0.1:10808` |
-| HTTP/1.1 TLS decrypt tunnel | `127.0.0.1:11666` |
-| HTTP/2 TLS decrypt tunnel | `127.0.0.1:11777` |
-
-## Manual authenticated installation
-
-Use this only when the router cannot reach GitHub Pages. Download the two APKs, `xray-mitm-feed-v1.pem`, `PUBLIC_KEY_SHA256`, and `SHA256SUMS` from the same signed GitHub Release on a Mac or Windows PC.
-
-**ROUTER:**
-
-```sh
-mkdir -p -m 0700 /tmp/xray-mitm-install
-```
-
-**MAC:**
-
-```sh
-cd "/path/to/downloaded/release-files"
-scp -O xray-mitm-*.apk luci-app-xray-mitm-*.apk \
-  xray-mitm-feed-v1.pem PUBLIC_KEY_SHA256 SHA256SUMS \
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-**WINDOWS PC (PowerShell):**
-
-```powershell
-Set-Location "C:\path\to\downloaded\release-files"
-scp.exe -O .\xray-mitm-*.apk .\luci-app-xray-mitm-*.apk `
-  .\xray-mitm-feed-v1.pem .\PUBLIC_KEY_SHA256 .\SHA256SUMS `
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-Verify the public-key fingerprint before installing it. Stop if it differs from the fingerprint in this README.
-
-**ROUTER:**
-
-```sh
-cd /tmp/xray-mitm-install
-printf '%s  %s\n' \
-  '3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a' \
-  'xray-mitm-feed-v1.pem' | sha256sum -c -
-awk '$2 ~ /[.]apk$/' SHA256SUMS | sha256sum -c -
-mkdir -p /etc/apk/keys
-cp xray-mitm-feed-v1.pem /etc/apk/keys/xray-mitm-feed-v1.pem
-chmod 0644 /etc/apk/keys/xray-mitm-feed-v1.pem
-apk add ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
-```
-
-CI development APKs are intentionally outside this production trust path. Do not present them to new users as signed releases.
-
-## Development and release testing
-
-See [Contributing](CONTRIBUTING.md) for the local branch and pull request workflow,
-and [Changelog](CHANGELOG.md) for user-facing release history.
-
-Run all offline safety, installer, routing, certificate, workflow, and syntax checks:
-
-**MAC:**
-
-```sh
-cd "/path/to/xray-mitm-openwrt"
-sh scripts/validate-release.sh
-```
-
-**WINDOWS PC (PowerShell with WSL):**
-
-```powershell
-wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
-```
-
-See [Release testing](docs/RELEASE_TESTING.md) before publishing a tag.
-
-## Removal
-
-Before removing the packages, stop the service, disable boot startup, and use the LuCI PassWall2 rollback if routing was applied. Then remove the packages:
+If routing was applied, roll it back in LuCI first. Then stop and remove the packages on the router:
 
 **ROUTER:**
 
@@ -288,8 +143,8 @@ Before removing the packages, stop the service, disable boot startup, and use th
 apk del luci-app-xray-mitm xray-mitm
 ```
 
-Remove `mycert.crt` from every client trust store when interception is no longer intended. Treat any remaining router backup and `mycert.key` as secret material.
+Remove `mycert.crt` from client trust stores when interception is no longer intended. Treat remaining backups and `mycert.key` as secret material.
 
 ## Attribution
 
-The domain-fronting configuration is derived from [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23), licensed under GPL-3.0. Xray-core, OpenWrt, LuCI, and PassWall2 remain separate upstream projects. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+The packaged domain-fronting configuration is derived from [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23), licensed under GPL-3.0. Xray-core, OpenWrt, LuCI, and PassWall2 remain separate upstream projects. See [third-party notices](THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security
+
+This project combines HTTPS interception with optional PassWall2 routing. Read this page before installing it.
+
+## MITM trust boundary
+
+A device that trusts the project CA can have HTTPS traffic decrypted for domains sent through the MITM service. Use the software only on networks and devices you own or are authorized to manage.
+
+- Install only the public certificate, `mycert.crt`, on clients.
+- Keep `mycert.key` on the router and in protected backups.
+- Do not place the private key in Git, release assets, screenshots, support messages, or terminal transcripts.
+- The service listeners are intended to remain on `127.0.0.1`.
+- Remove the public certificate from clients when interception is no longer intended.
+
+Some applications ignore user-installed CAs or use certificate pinning. A successful router health check does not prove that every application or client will accept the certificate.
+
+## Signed package feed
+
+The installer and package feed use separate checks:
+
+```text
+download installer over HTTPS
+→ verify the pinned installer SHA-256
+→ download the feed public key
+→ verify the feed key fingerprint
+→ let APK verify the signed package index and packages
+```
+
+The current public feed key is:
+
+```text
+File: keys/xray-mitm-feed-v1.pem
+SHA-256: 3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
+```
+
+The installer does not use `--allow-untrusted` and does not run an unrestricted system-wide package upgrade. It targets `xray-mitm` and `luci-app-xray-mitm` and keeps a protected backup before changing feed state.
+
+## Production signing boundary
+
+Pull-request builds are development artifacts. They do not receive the production signing private key. Production feed signing runs only through the protected GitHub environment `signed-feed`.
+
+The publishing workflow checks that the protected private key derives the same public key as the committed `keys/xray-mitm-feed-v1.pem`. The private key is never stored in this repository, package files, workflow artifacts, release assets, router images, or commands.
+
+For key storage, publishing, recovery, and rotation procedures, see [Signed feed operations](docs/SIGNED_FEED.md).
+
+## Reporting a security issue
+
+Do not post private keys, router backups, credentials, or sensitive router configuration in a public issue. Use the repository's private GitHub security reporting channel when available, or contact the maintainer privately with the minimum reproducible information.
+

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,0 +1,115 @@
+# Advanced usage
+
+Most users should follow the main [README](../README.md). This page documents the controls and implementation details that are useful when the Basic dashboard needs more information.
+
+## Dashboard modes
+
+The LuCI page uses one client-side view with two modes:
+
+- **Basic** — setup, certificate download, recommended routing, and status.
+- **Advanced** — **Overview**, **Service**, **Certificates**, and **Routing** pages for manual control.
+
+Switching pages does not reload the LuCI view.
+
+## Service and local listeners
+
+Installing or updating packages does not start the service. The Advanced **Service** page can install the packaged default configuration, start or stop the service, enable or disable automatic startup, and run the MITM health check.
+
+The service is designed to keep its listeners on localhost:
+
+| Purpose | Address |
+| --- | --- |
+| Local mixed/SOCKS entry | `127.0.0.1:10808` |
+| HTTP/1.1 TLS decrypt tunnel | `127.0.0.1:11666` |
+| HTTP/2 TLS decrypt tunnel | `127.0.0.1:11777` |
+
+The local SOCKS listener is for the PassWall2 MITM-compatible route. It should not be exposed to the LAN or Internet.
+
+## Certificate lifecycle
+
+The **Certificates** page can show three certificate states:
+
+- **Current** — the active certificate and matching private key used by the service.
+- **Candidate** — a new certificate pair prepared but not yet active.
+- **Previous** — the prior active pair kept for rollback when available.
+
+The application validates certificate and key matching before activation. A candidate is not the same as the current certificate. Clients must trust the public certificate that matches the current active pair.
+
+Only export the public certificate. The private key must remain root-owned with restrictive permissions on the router and in protected backups.
+
+## PassWall2 routing model
+
+The Routing page uses three package-managed rules. Their user-facing names and destinations are:
+
+1. **VPN Overrides** — sends selected Gemini, Android connectivity, YouTube control, and Google Account bundles to the chosen VPN.
+2. **MITM-Compatible Services** — sends selected Google, Meta, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`.
+3. **Regional Direct Access** — sends selected Iranian domains and IP ranges directly.
+
+The available service groups currently map as follows:
+
+| Group | Entries |
+| --- | --- |
+| Gemini app and API | `gemini.google.com`, `generativelanguage.googleapis.com` |
+| Android internet checks | `connectivitycheck.gstatic.com`, `connectivitycheck.android.com`, `clients3.google.com` |
+| YouTube sign-in and controls | `www.youtube.com`, `youtubei.googleapis.com`, `youtube.googleapis.com`, `accounts.youtube.com` |
+| Google Account sign-in | `accounts.google.com` |
+| Google services | `geosite:google` |
+| Meta websites | `geosite:meta` |
+| Fastly-backed websites | `geosite:fastly`, `geosite:reddit`, `geosite:cnn`, `buzzfeed.com` |
+| Iranian websites and IP addresses | `geosite:ir`, `geoip:ir` |
+
+`googlevideo.com` is deliberately excluded from YouTube control routing so video delivery can remain on the MITM path.
+
+The checkboxes select entries inside these assignments. They do not create one PassWall2 rule per checkbox. The assistant creates or reuses the local SOCKS node when needed, previews the exact change, and applies it only after the reviewed preview is accepted.
+
+The first three-rule apply can migrate older package-managed rules. It preserves unrelated user-created rules while removing their selected-shunt assignments when necessary to avoid duplicate matches. The advanced option `localhost_proxy=0` prevents the local MITM connection from being captured again.
+
+## Preview, apply, rollback, and recovery
+
+The routing assistant requires a compatible PassWall2 installation, a selected shunt, a working VPN node, and a writable configuration. It refuses a MITM-dependent apply while the MITM service is stopped.
+
+The assistant creates a private temporary preview first. Applying is limited to that exact preview, and a rollback copy is kept. If an interrupted transaction is reported, use **Recover previous PassWall2 file** before creating another preview.
+
+Pending PassWall2 changes must be saved or reverted before a new preview can be created.
+
+## CLI reference
+
+These commands run on the router. Most return JSON; certificate export returns the public certificate.
+
+**ROUTER:**
+
+```sh
+xray-mitmctl status-json
+xray-mitmctl setup-status-json
+xray-mitmctl setup-recommended
+xray-mitmctl health-json
+xray-mitmctl service start
+xray-mitmctl service stop
+xray-mitmctl service enable
+xray-mitmctl service disable
+xray-mitmctl config-install-default
+xray-mitmctl cert-status-json
+xray-mitmctl cert-export current
+xray-mitmctl passwall2 inspect
+xray-mitmctl passwall2 recover
+```
+
+Certificate generation, import, activation, discard, and rollback require the exact fingerprint arguments shown by the certificate status and are safer through the Advanced page.
+
+## Manual authenticated package installation
+
+Use this only when the router cannot reach GitHub Pages. Download both APKs and the matching `xray-mitm-feed-v1.pem`, `PUBLIC_KEY_SHA256`, and `SHA256SUMS` from one signed GitHub Release. Verify the public-key fingerprint and package checksums before installing.
+
+The current feed-key SHA-256 is documented in [Security](../SECURITY.md). Never use `--allow-untrusted` and never mix APKs from different releases.
+
+## Removal
+
+If PassWall2 routing was applied, roll it back first. On the router, stop and disable the service before removing both packages:
+
+**ROUTER:**
+
+```sh
+/etc/init.d/xray-mitm stop
+/etc/init.d/xray-mitm disable
+apk del luci-app-xray-mitm xray-mitm
+```

--- a/docs/RELEASE_TESTING.md
+++ b/docs/RELEASE_TESTING.md
@@ -38,9 +38,12 @@ JavaScript, templates, styles, RPC data, and ACL access.
    preserved unless the release intentionally changes them.
 7. Save the tested commit, candidate version, page, control results, console result,
    and any screenshot in the release or pull-request evidence.
+8. Present the exact tested UI candidate to the project owner and record explicit
+   visual approval before pushing, merging, tagging, or publishing it.
 
 A syntax check, mocked frontend test, successful APK build, or green GitHub Actions
-run is insufficient by itself. Do not merge or publish until this gate passes.
+run is insufficient by itself. The owner's silence is not UI approval. Do not push,
+merge, tag, or publish until both the browser test and visual approval pass.
 
 ## 3. Signed publishing checks
 

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -5,6 +5,9 @@
 'require dom';
 'require xray-mitm.state as state';
 
+/* Keep this fallback synchronized with xray-mitm/Makefile PKG_VERSION. */
+var PROJECT_VERSION = '0.4.2';
+
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',
 	method: 'getStatus',
@@ -529,57 +532,73 @@ return view.extend({
 			dom.content(target, statusPill(label, tone));
 	},
 
-	routeContext: function() {
-		var path = (L.env && L.env.dispatchpath) || [];
-		var mode = path[3] === 'advanced' ? 'advanced' : 'basic';
-		var allowed = mode === 'advanced' ?
-			[ 'overview', 'service', 'certificates', 'routing' ] :
-			[ 'overview', 'setup', 'routing', 'status' ];
-		var page = path[4] || 'overview';
-
-		return {
-			mode: mode,
-			page: allowed.indexOf(page) > -1 ? page : 'overview'
-		};
-	},
-
-	pageNavigation: function(route) {
+	pageNavigation: function() {
 		var groups = [
 			{ name: 'basic', label: _('Basic') },
 			{ name: 'advanced', label: _('Advanced') }
 		];
-		var pages = route.mode === 'advanced' ? [
+		var advancedPages = [
 			{ name: 'overview', label: _('Overview') },
 			{ name: 'service', label: _('Service') },
 			{ name: 'certificates', label: _('Certificates') },
 			{ name: 'routing', label: _('Routing') }
-		] : [
+		];
+		var basicPages = [
 			{ name: 'overview', label: _('Overview') },
 			{ name: 'setup', label: _('Setup') },
 			{ name: 'routing', label: _('Routing') },
 			{ name: 'status', label: _('Status') }
 		];
-		var tabRow = function(items, active, href) {
-			return E('ul', { class: 'tabs', style: 'margin-bottom:.5rem' }, items.map(function(item) {
-				return E('li', { class: item.name === active ? 'active' : '' }, E('a', {
-					href: href(item.name)
+		var tabRow = function(items, mode, active, style) {
+			return E('ul', {
+				class: 'cbi-tabmenu',
+				'data-dashboard-tabs': mode,
+				style: style || ''
+			}, items.map(function(item) {
+				return E('li', {
+					class: item.name === active ? 'cbi-tab' : 'cbi-tab-disabled',
+					'data-dashboard-tab-mode': mode,
+					'data-dashboard-tab-page': item.name
+				}, E('a', {
+					href: '#',
+					click: ui.createHandlerFn(this, 'switchDashboardPage', mode, item.name)
 				}, item.label));
-			}));
-		};
+			}, this));
+		}.bind(this);
 
 		return E('nav', { 'aria-label': _('MITM Domain Fronting pages') }, [
-			tabRow(groups, route.mode, function(mode) {
-				return L.url('admin/services/xray-mitm/' + mode + '/overview');
-			}),
-			tabRow(pages, route.page, function(page) {
-				return L.url('admin/services/xray-mitm/' + route.mode + '/' + page);
-			})
+			tabRow(groups, 'mode', 'basic'),
+			tabRow(basicPages, 'basic', 'overview'),
+			tabRow(advancedPages, 'advanced', '', 'display:none')
 		]);
 	},
 
-	switchMode: function(mode) {
-		window.location.href = L.url('admin/services/xray-mitm/' +
-			(mode === 'advanced' ? 'advanced' : 'basic') + '/overview');
+	switchDashboardPage: function(mode, page) {
+		var targetPage = mode === 'mode' ? 'overview' : page;
+		var targetMode = mode === 'mode' ? page : mode;
+		var simple = document.getElementById('xray-mitm-simple');
+		var advanced = document.getElementById('xray-mitm-advanced');
+
+		if (simple)
+			simple.style.display = targetMode === 'basic' ? '' : 'none';
+		if (advanced)
+			advanced.style.display = targetMode === 'advanced' ? '' : 'none';
+
+		document.querySelectorAll('[data-dashboard-panel-mode]').forEach(function(panel) {
+			panel.style.display = panel.getAttribute('data-dashboard-panel-mode') === targetMode &&
+				panel.getAttribute('data-dashboard-panel-page') === targetPage ? '' : 'none';
+		});
+		document.querySelectorAll('[data-dashboard-tabs]').forEach(function(row) {
+			var name = row.getAttribute('data-dashboard-tabs');
+			row.style.display = name === 'mode' || name === targetMode ? '' : 'none';
+		});
+		document.querySelectorAll('[data-dashboard-tab-mode]').forEach(function(tab) {
+			var tabMode = tab.getAttribute('data-dashboard-tab-mode');
+			var tabPage = tab.getAttribute('data-dashboard-tab-page');
+			var active = tabMode === 'mode' ? tabPage === targetMode :
+				tabMode === targetMode && tabPage === targetPage;
+			tab.className = active ? 'cbi-tab' : 'cbi-tab-disabled';
+		});
 	},
 
 	reviewRecommendedRouting: function(ev) {
@@ -854,6 +873,68 @@ return view.extend({
 		]);
 	},
 
+	overviewStatusStrip: function(status, certificates, passwall) {
+		var passwallState = (this.setup && this.setup.passwall2) || {};
+		var routingState = (passwall && passwall.routing_state) || {};
+		var current = slotData(certificates, 'current');
+		var cards = [
+			{
+				icon: '◆', label: _('MITM service'),
+				value: status.running === true ? _('Running') : _('Stopped'),
+				tone: status.running === true ? 'good' : 'warn', detail: '127.0.0.1:10808'
+			},
+			{
+				icon: '◉', label: _('PassWall2'),
+				value: passwallState.installed === true ? _('Ready') : _('Not detected'),
+				tone: passwallState.installed === true ? 'good' : 'warn', detail: _('Routing integration')
+			},
+			{
+				icon: '↔', label: _('PassWall2 routing'),
+				value: passwallState.shunt_available === true && passwallState.vpn_available === true ?
+					_('Ready') : _('Needs attention'),
+				tone: passwallState.shunt_available === true && passwallState.vpn_available === true ? 'good' : 'warn',
+				detail: routingState.configured === true ? _('Rules configured') : _('Choose your rules')
+			},
+			{
+				icon: '✓', label: _('Public certificate'),
+				value: slotPresent(current) ? _('Ready') : _('Needed'),
+				tone: slotPresent(current) ? 'good' : 'warn', detail: _('Private key stays on router')
+			}
+		];
+		var toneColors = { good: '#2f7d32', warn: '#a15c00' };
+
+		return E('div', {}, [
+			E('style', {}, '@media(max-width:900px){.xray-mitm-status-strip,.xray-mitm-step-strip{grid-template-columns:repeat(2,minmax(0,1fr))!important}}' +
+				'@media(max-width:520px){.xray-mitm-status-strip,.xray-mitm-step-strip{grid-template-columns:1fr!important}}'),
+			E('div', {
+				class: 'xray-mitm-status-strip',
+				style: 'display:grid!important;grid-template-columns:repeat(4,minmax(0,1fr))!important;' +
+					'align-items:stretch;gap:.7rem;width:100%;box-sizing:border-box;' +
+					'padding:.75rem;margin:1rem 0;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(128,128,128,.12)'
+			}, cards.map(function(card) {
+			return E('div', {
+				class: 'xray-mitm-status-card',
+				style: 'display:flex;align-items:center;gap:.8rem;width:100%;min-height:5.25rem;' +
+					'padding:.75rem .9rem;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(0,0,0,.12);box-sizing:border-box'
+			}, [
+				E('span', {
+					'aria-hidden': 'true',
+					style: 'display:inline-flex;align-items:center;justify-content:center;width:2.35rem;height:2.35rem;' +
+						'flex:0 0 2.35rem;border-radius:50%;background:rgba(94,114,228,.16);' +
+						'color:#5e72e4;font-size:1.35rem;font-weight:700'
+				}, card.icon),
+				E('div', { style: 'min-width:0' }, [
+					E('strong', { style: 'display:block;line-height:1.2' }, card.label),
+					E('span', { style: 'display:block;margin-top:.2rem;font-weight:700;color:' + toneColors[card.tone] }, card.value),
+					E('small', { style: 'display:block;margin-top:.15rem;opacity:.72;white-space:nowrap;overflow:hidden;text-overflow:ellipsis' }, card.detail)
+				])
+			]);
+			}))
+		]);
+	},
+
 	simpleRoutingTable: function(routing, passwall) {
 		routing = routing || {};
 		passwall = passwall || {};
@@ -932,14 +1013,10 @@ return view.extend({
 		var pageStyle = function(name) { return page === name ? '' : 'display:none'; };
 
 		return E('div', { id: 'xray-mitm-simple' }, [
-			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section', style: pageStyle('overview') }, [
+			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'overview', style: pageStyle('overview') }, [
 				E('h3', {}, _('Basic settings')),
-				E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(13rem,1fr));gap:.7rem;margin:1rem 0' }, [
-					this.simpleStatusCard(_('MITM service'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn', _('Local SOCKS: 127.0.0.1:10808')),
-					this.simpleStatusCard(_('PassWall2'), passwallState.installed === true ? _('Detected') : _('Not detected'), passwallState.installed === true ? 'good' : 'warn'),
-					this.simpleStatusCard(_('Routing profile'), passwallState.shunt_available === true ? _('Available') : _('Missing'), passwallState.shunt_available === true ? 'good' : 'warn'),
-					this.simpleStatusCard(_('Working VPN'), passwallState.vpn_available === true ? _('Available') : _('Missing'), passwallState.vpn_available === true ? 'good' : 'warn')
-				]),
+				this.overviewStatusStrip(status, certificates, passwall),
 				this.simpleStateRow(_('MITM application'), _('Installed'), 'good', _('The router backend is connected.')),
 				this.simpleStateRow(_('PassWall2'), passwallState.installed === true ? _('Detected') : _('Not detected'),
 					passwallState.installed === true ? 'good' : 'warn'),
@@ -948,7 +1025,8 @@ return view.extend({
 				this.simpleStateRow(_('VPN connection'), passwallState.vpn_available === true ? _('Available') : _('Missing'),
 					passwallState.vpn_available === true ? 'good' : 'warn')
 			]),
-			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section', style: pageStyle('setup') }, [
+			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'setup', style: pageStyle('setup') }, [
 				E('h3', {}, _('Setup')),
 				this.simpleStateRow(_('Router configuration'), setup.config && setup.config.present === true ? _('Ready') : _('Needed'),
 					setup.config && setup.config.present === true ? 'good' : 'warn'),
@@ -965,7 +1043,8 @@ return view.extend({
 					click: ui.createHandlerFn(this, 'setupRecommended')
 				}, setupComplete ? _('Setup complete') : _('Set up automatically')))
 			]),
-			E('div', { class: 'cbi-section', style: pageStyle('setup') }, [
+			E('div', { class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'setup', style: pageStyle('setup') }, [
 				E('h3', {}, _('Certificate for your device')),
 				E('p', {}, _('Devices using MITM websites must trust this public certificate. The private key stays on the router.')),
 				certificateReady && slotPresent(current) ? E('p', {}, E('button', {
@@ -984,7 +1063,8 @@ return view.extend({
 					])
 				])
 			]),
-			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section', style: pageStyle('routing') }, [
+			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'routing', style: pageStyle('routing') }, [
 				E('h3', {}, _('Routing rules')),
 				E('p', {}, _('Choose the service groups to use. The table shows the destination that will be assigned in PassWall2.')),
 				passwallState.installed !== true ? E('div', { class: 'alert-message warning' }, _(
@@ -1008,7 +1088,8 @@ return view.extend({
 					E('div', { id: 'xray-mitm-simple-routing-preview', 'aria-live': 'polite' })
 				]) : ''
 			]),
-			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section', style: pageStyle('status') }, [
+			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section cbi-tabcontainer',
+				'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'status', style: pageStyle('status') }, [
 				E('h3', {}, _('Status')),
 				this.simpleStateRow(_('MITM'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn'),
 				this.simpleStateRow(_('Routing'), routingState.recommended_matches_current === true ? _('Recommended') :
@@ -1066,10 +1147,18 @@ return view.extend({
 			E('p', {}, firstTime ?
 				_('Complete these steps once, in order. Green items are already ready.') :
 				_('Updates preserve your configuration and certificate. These cards show the current state; complete only items that are not ready.')),
-			E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(14rem,1fr));gap:.75rem' },
-				steps.map(function(step) {
+			this.overviewStatusStrip(status, certificates, passwall),
+			E('div', {
+				class: 'xray-mitm-step-strip',
+				style: 'display:grid!important;grid-template-columns:repeat(4,minmax(0,1fr))!important;' +
+					'align-items:stretch;gap:.7rem;width:100%;box-sizing:border-box;' +
+					'padding:.75rem;margin:1rem 0;border:1px solid var(--border-color-medium,#ccc);' +
+					'border-radius:.35rem;background:rgba(128,128,128,.12)'
+			}, steps.map(function(step) {
 					return E('div', {
-						style: 'padding:1rem;border:1px solid var(--border-color-medium,#ccc);border-radius:.45rem'
+						style: 'display:flex;flex-direction:column;justify-content:center;width:100%;min-height:5.25rem;' +
+							'padding:.75rem .9rem;border:1px solid var(--border-color-medium,#ccc);' +
+							'border-radius:.35rem;background:rgba(0,0,0,.12);box-sizing:border-box'
 					}, [
 						E('div', { style: 'display:flex;align-items:center;gap:.55rem;margin-bottom:.45rem' }, [
 							statusPill(step.done ? '✓' : (firstTime ? step.number : '!'), step.done ? 'good' : 'warn'),
@@ -1346,33 +1435,46 @@ return view.extend({
 		this.status = data[1] || {};
 		this.certificates = data[2] || {};
 		this.passwall = data[3] || {};
+		this.appVersion = text(this.setup.app_version || this.setup.version, PROJECT_VERSION)
+			.replace(/^v/i, '');
 		this.planToken = null;
 		this.rollbackTransaction = this.passwall.rollback_transaction || null;
-		var route = this.routeContext();
-		var advancedPages = {
-			overview: this.renderSetupGuide(this.status, this.certificates, this.passwall),
-			service: this.renderService(this.status),
-			certificates: this.renderCertificates(this.certificates),
-			routing: this.renderRouting(this.passwall)
-		};
 
 		return E('div', {}, [
-			E('h2', {}, _('MITM Domain Fronting')),
+			E('h2', { style: 'display:flex;align-items:center;gap:.65rem;flex-wrap:wrap' }, [
+				_('MITM Domain Fronting'),
+				E('span', {
+					class: 'xray-mitm-version-badge',
+					title: _('Application version'),
+					style: 'display:inline-block;padding:.18rem .55rem;border:1px solid var(--border-color-medium,#ccc);' +
+						'border-radius:999px;font-size:.55em;font-weight:600;line-height:1.2;opacity:.82'
+				}, 'v' + this.appVersion)
+			]),
 			E('p', {}, _(
 				'Prepare the MITM service, download the public certificate, and configure safe PassWall2 routing.'
 			)),
-			this.pageNavigation(route),
+			this.pageNavigation(),
 			this.setup.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.setup.error, _('Unable to read setup status.'))) : '',
-			route.mode === 'basic' ? this.renderSimple(
-				this.setup, this.status, this.certificates, this.passwall, route.page
-			) : '',
-			route.mode === 'advanced' ? E('div', { id: 'xray-mitm-advanced' }, [
+			this.renderSimple(this.setup, this.status, this.certificates, this.passwall, 'overview'),
+			E('div', { id: 'xray-mitm-advanced', style: 'display:none' }, [
 				E('div', { class: 'alert-message notice' }, _(
 					'Advanced settings expose manual service, certificate, transaction, and routing controls.'
 				)),
-				route.page === 'service' && this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
-				advancedPages[route.page]
-			]) : '',
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'overview', style: 'display:none' },
+				this.renderSetupGuide(this.status, this.certificates, this.passwall)),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'service', style: 'display:none' }, [
+					this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
+					this.renderService(this.status)
+				]),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'certificates', style: 'display:none' },
+				this.renderCertificates(this.certificates)),
+				E('div', { class: 'cbi-tabcontainer', 'data-dashboard-panel-mode': 'advanced',
+					'data-dashboard-panel-page': 'routing', style: 'display:none' },
+				this.renderRouting(this.passwall))
+			]),
 			E('div', { class: 'alert-message warning' }, _(
 				'Trust the public CA only on devices you control. Never copy, publish, or download the router private CA key.'
 			))

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -529,25 +529,57 @@ return view.extend({
 			dom.content(target, statusPill(label, tone));
 	},
 
+	routeContext: function() {
+		var path = (L.env && L.env.dispatchpath) || [];
+		var mode = path[3] === 'advanced' ? 'advanced' : 'basic';
+		var allowed = mode === 'advanced' ?
+			[ 'overview', 'service', 'certificates', 'routing' ] :
+			[ 'overview', 'setup', 'routing', 'status' ];
+		var page = path[4] || 'overview';
+
+		return {
+			mode: mode,
+			page: allowed.indexOf(page) > -1 ? page : 'overview'
+		};
+	},
+
+	pageNavigation: function(route) {
+		var groups = [
+			{ name: 'basic', label: _('Basic') },
+			{ name: 'advanced', label: _('Advanced') }
+		];
+		var pages = route.mode === 'advanced' ? [
+			{ name: 'overview', label: _('Overview') },
+			{ name: 'service', label: _('Service') },
+			{ name: 'certificates', label: _('Certificates') },
+			{ name: 'routing', label: _('Routing') }
+		] : [
+			{ name: 'overview', label: _('Overview') },
+			{ name: 'setup', label: _('Setup') },
+			{ name: 'routing', label: _('Routing') },
+			{ name: 'status', label: _('Status') }
+		];
+		var tabRow = function(items, active, href) {
+			return E('ul', { class: 'tabs', style: 'margin-bottom:.5rem' }, items.map(function(item) {
+				return E('li', { class: item.name === active ? 'active' : '' }, E('a', {
+					href: href(item.name)
+				}, item.label));
+			}));
+		};
+
+		return E('nav', { 'aria-label': _('MITM Domain Fronting pages') }, [
+			tabRow(groups, route.mode, function(mode) {
+				return L.url('admin/services/xray-mitm/' + mode + '/overview');
+			}),
+			tabRow(pages, route.page, function(page) {
+				return L.url('admin/services/xray-mitm/' + route.mode + '/' + page);
+			})
+		]);
+	},
+
 	switchMode: function(mode) {
-		var simple = document.getElementById('xray-mitm-simple');
-		var advanced = document.getElementById('xray-mitm-advanced');
-		var simpleButton = document.getElementById('xray-mitm-mode-simple');
-		var advancedButton = document.getElementById('xray-mitm-mode-advanced');
-		var showAdvanced = mode === 'advanced';
-		if (simple)
-			simple.style.display = showAdvanced ? 'none' : '';
-		if (advanced)
-			advanced.style.display = showAdvanced ? '' : 'none';
-		if (simpleButton)
-			simpleButton.className = showAdvanced ? 'btn' : 'btn cbi-button-action';
-		if (simpleButton)
-			simpleButton.setAttribute('aria-pressed', showAdvanced ? 'false' : 'true');
-		if (advancedButton)
-			advancedButton.className = showAdvanced ? 'btn cbi-button-action' : 'btn';
-		if (advancedButton)
-			advancedButton.setAttribute('aria-pressed', showAdvanced ? 'true' : 'false');
-		window.scrollTo({ top: 0, behavior: 'smooth' });
+		window.location.href = L.url('admin/services/xray-mitm/' +
+			(mode === 'advanced' ? 'advanced' : 'basic') + '/overview');
 	},
 
 	reviewRecommendedRouting: function(ev) {
@@ -822,24 +854,6 @@ return view.extend({
 		]);
 	},
 
-	simpleNavigation: function() {
-		return E('nav', {
-			'aria-label': _('MITM Domain Fronting sections'),
-			style: 'display:flex;gap:.35rem;flex-wrap:wrap;margin:1rem 0'
-		}, [
-			[ 'xray-mitm-simple-basic', _('Basic settings') ],
-			[ 'xray-mitm-simple-certificate', _('Certificate') ],
-			[ 'xray-mitm-simple-routing', _('Routing rules') ],
-			[ 'xray-mitm-simple-status', _('Status') ]
-		].map(function(item) {
-			return E('a', {
-				href: '#' + item[0],
-				class: 'btn',
-				style: 'text-decoration:none'
-			}, item[1]);
-		}));
-	},
-
 	simpleRoutingTable: function(routing, passwall) {
 		routing = routing || {};
 		passwall = passwall || {};
@@ -901,7 +915,7 @@ return view.extend({
 		]));
 	},
 
-	renderSimple: function(setup, status, certificates, passwall) {
+	renderSimple: function(setup, status, certificates, passwall, page) {
 		var current = slotData(certificates, 'current');
 		var certificateReady = setup.certificate && setup.certificate.ready === true;
 		var candidateAttention = setup.certificate && setup.certificate.candidate_requires_attention === true;
@@ -915,10 +929,10 @@ return view.extend({
 			routingState.recovery_pending !== true && shunts.length > 0 && vpns.length > 0;
 		var setupBlocked = candidateAttention || certificateAttention;
 		var setupComplete = setup.ready === true && setup.service && setup.service.boot_enabled === true;
+		var pageStyle = function(name) { return page === name ? '' : 'display:none'; };
 
 		return E('div', { id: 'xray-mitm-simple' }, [
-			this.simpleNavigation(),
-			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-basic', class: 'cbi-section', style: pageStyle('overview') }, [
 				E('h3', {}, _('Basic settings')),
 				E('div', { style: 'display:grid;grid-template-columns:repeat(auto-fit,minmax(13rem,1fr));gap:.7rem;margin:1rem 0' }, [
 					this.simpleStatusCard(_('MITM service'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn', _('Local SOCKS: 127.0.0.1:10808')),
@@ -934,7 +948,7 @@ return view.extend({
 				this.simpleStateRow(_('VPN connection'), passwallState.vpn_available === true ? _('Available') : _('Missing'),
 					passwallState.vpn_available === true ? 'good' : 'warn')
 			]),
-			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-certificate', class: 'cbi-section', style: pageStyle('setup') }, [
 				E('h3', {}, _('Setup')),
 				this.simpleStateRow(_('Router configuration'), setup.config && setup.config.present === true ? _('Ready') : _('Needed'),
 					setup.config && setup.config.present === true ? 'good' : 'warn'),
@@ -951,7 +965,7 @@ return view.extend({
 					click: ui.createHandlerFn(this, 'setupRecommended')
 				}, setupComplete ? _('Setup complete') : _('Set up automatically')))
 			]),
-			E('div', { class: 'cbi-section' }, [
+			E('div', { class: 'cbi-section', style: pageStyle('setup') }, [
 				E('h3', {}, _('Certificate for your device')),
 				E('p', {}, _('Devices using MITM websites must trust this public certificate. The private key stays on the router.')),
 				certificateReady && slotPresent(current) ? E('p', {}, E('button', {
@@ -970,7 +984,7 @@ return view.extend({
 					])
 				])
 			]),
-			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-routing', class: 'cbi-section', style: pageStyle('routing') }, [
 				E('h3', {}, _('Routing rules')),
 				E('p', {}, _('Choose the service groups to use. The table shows the destination that will be assigned in PassWall2.')),
 				passwallState.installed !== true ? E('div', { class: 'alert-message warning' }, _(
@@ -994,7 +1008,7 @@ return view.extend({
 					E('div', { id: 'xray-mitm-simple-routing-preview', 'aria-live': 'polite' })
 				]) : ''
 			]),
-			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section' }, [
+			E('div', { id: 'xray-mitm-simple-status', class: 'cbi-section', style: pageStyle('status') }, [
 				E('h3', {}, _('Status')),
 				this.simpleStateRow(_('MITM'), status.running === true ? _('Running') : _('Stopped'), status.running === true ? 'good' : 'warn'),
 				this.simpleStateRow(_('Routing'), routingState.recommended_matches_current === true ? _('Recommended') :
@@ -1010,10 +1024,7 @@ return view.extend({
 					class: 'btn cbi-button-action', disabled: status.running === true ? null : '',
 					click: ui.createHandlerFn(this, 'runHealth')
 				}, _('Run check')))
-			]),
-			E('p', {}, E('button', {
-				class: 'btn', click: ui.createHandlerFn(this, 'switchMode', 'advanced')
-			}, _('Advanced settings →')))
+			])
 		]);
 	},
 
@@ -1337,34 +1348,31 @@ return view.extend({
 		this.passwall = data[3] || {};
 		this.planToken = null;
 		this.rollbackTransaction = this.passwall.rollback_transaction || null;
+		var route = this.routeContext();
+		var advancedPages = {
+			overview: this.renderSetupGuide(this.status, this.certificates, this.passwall),
+			service: this.renderService(this.status),
+			certificates: this.renderCertificates(this.certificates),
+			routing: this.renderRouting(this.passwall)
+		};
 
 		return E('div', {}, [
 			E('h2', {}, _('MITM Domain Fronting')),
 			E('p', {}, _(
 				'Prepare the MITM service, download the public certificate, and configure safe PassWall2 routing.'
 			)),
-			E('div', { style: 'display:flex;gap:.5rem;margin:1rem 0' }, [
-				E('button', {
-					id: 'xray-mitm-mode-simple', class: 'btn cbi-button-action', 'aria-pressed': 'true',
-					click: ui.createHandlerFn(this, 'switchMode', 'simple')
-				}, _('Simple')),
-				E('button', {
-					id: 'xray-mitm-mode-advanced', class: 'btn', 'aria-pressed': 'false',
-					click: ui.createHandlerFn(this, 'switchMode', 'advanced')
-				}, _('Advanced'))
-			]),
+			this.pageNavigation(route),
 			this.setup.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.setup.error, _('Unable to read setup status.'))) : '',
-			this.renderSimple(this.setup, this.status, this.certificates, this.passwall),
-			E('div', { id: 'xray-mitm-advanced', style: 'display:none' }, [
+			route.mode === 'basic' ? this.renderSimple(
+				this.setup, this.status, this.certificates, this.passwall, route.page
+			) : '',
+			route.mode === 'advanced' ? E('div', { id: 'xray-mitm-advanced' }, [
 				E('div', { class: 'alert-message notice' }, _(
 					'Advanced settings expose manual service, certificate, transaction, and routing controls.'
 				)),
-				this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
-				this.renderSetupGuide(this.status, this.certificates, this.passwall),
-				this.renderService(this.status),
-				this.renderCertificates(this.certificates),
-				this.renderRouting(this.passwall)
-			]),
+				route.page === 'service' && this.status.ok === false ? E('div', { class: 'alert-message danger' }, textNode(this.status.error, _('Unable to read service status.'))) : '',
+				advancedPages[route.page]
+			]) : '',
 			E('div', { class: 'alert-message warning' }, _(
 				'Trust the public CA only on devices you control. Never copy, publish, or download the router private CA key.'
 			))

--- a/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
@@ -2,12 +2,57 @@
 	"admin/services/xray-mitm": {
 		"title": "MITM Domain Fronting",
 		"order": 91,
-		"action": {
-			"type": "view",
-			"path": "xray-mitm/overview"
-		},
-		"depends": {
-			"acl": [ "luci-app-xray-mitm" ]
-		}
+		"action": { "type": "firstchild" },
+		"depends": { "acl": [ "luci-app-xray-mitm" ] }
+	},
+	"admin/services/xray-mitm/basic": {
+		"title": "Basic",
+		"order": 10,
+		"action": { "type": "firstchild" }
+	},
+	"admin/services/xray-mitm/basic/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/setup": {
+		"title": "Setup",
+		"order": 20,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/routing": {
+		"title": "Routing",
+		"order": 30,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/basic/status": {
+		"title": "Status",
+		"order": 40,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced": {
+		"title": "Advanced",
+		"order": 20,
+		"action": { "type": "firstchild" }
+	},
+	"admin/services/xray-mitm/advanced/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/service": {
+		"title": "Service",
+		"order": 20,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/certificates": {
+		"title": "Certificates",
+		"order": 30,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
+	},
+	"admin/services/xray-mitm/advanced/routing": {
+		"title": "Routing",
+		"order": 40,
+		"action": { "type": "view", "path": "xray-mitm/overview" }
 	}
 }

--- a/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/luci/menu.d/luci-app-xray-mitm.json
@@ -2,57 +2,12 @@
 	"admin/services/xray-mitm": {
 		"title": "MITM Domain Fronting",
 		"order": 91,
-		"action": { "type": "firstchild" },
-		"depends": { "acl": [ "luci-app-xray-mitm" ] }
-	},
-	"admin/services/xray-mitm/basic": {
-		"title": "Basic",
-		"order": 10,
-		"action": { "type": "firstchild" }
-	},
-	"admin/services/xray-mitm/basic/overview": {
-		"title": "Overview",
-		"order": 10,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/setup": {
-		"title": "Setup",
-		"order": 20,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/routing": {
-		"title": "Routing",
-		"order": 30,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/basic/status": {
-		"title": "Status",
-		"order": 40,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced": {
-		"title": "Advanced",
-		"order": 20,
-		"action": { "type": "firstchild" }
-	},
-	"admin/services/xray-mitm/advanced/overview": {
-		"title": "Overview",
-		"order": 10,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/service": {
-		"title": "Service",
-		"order": 20,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/certificates": {
-		"title": "Certificates",
-		"order": 30,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
-	},
-	"admin/services/xray-mitm/advanced/routing": {
-		"title": "Routing",
-		"order": 40,
-		"action": { "type": "view", "path": "xray-mitm/overview" }
+		"action": {
+			"type": "view",
+			"path": "xray-mitm/overview"
+		},
+		"depends": {
+			"acl": [ "luci-app-xray-mitm" ]
+		}
 	}
 }

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -8,6 +8,8 @@ const modulePath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'xray-mitm', 'state.js');
 const overviewPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'htdocs',
 	'luci-static', 'resources', 'view', 'xray-mitm', 'overview.js');
+const menuPath = path.join(__dirname, '..', 'luci-app-xray-mitm', 'root',
+	'usr', 'share', 'luci', 'menu.d', 'luci-app-xray-mitm.json');
 
 function loadLuciModule(moduleSource, modules, globals) {
 	const dependencies = [];
@@ -146,7 +148,11 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		return { tag: tag, attributes: attributes, children: children };
 	};
 	const fakeDocument = { createTextNode: function(value) { return value; } };
-	const fakeLuCI = { bind: function(fn, context) { return fn.bind(context); } };
+	const fakeLuCI = {
+		bind: function(fn, context) { return fn.bind(context); },
+		env: { dispatchpath: [ 'admin', 'services', 'xray-mitm', 'basic', 'overview' ] },
+		url: function(value) { return '/' + value; }
+	};
 	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
 
 	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
@@ -162,6 +168,28 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});
 	});
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'basic', page: 'overview' });
+	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'certificates' ];
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'certificates' });
+	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'unknown' ];
+	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'overview' });
+}
+
+function testRoutedPageMenu() {
+	const menu = JSON.parse(fs.readFileSync(menuPath, 'utf8'));
+	const root = 'admin/services/xray-mitm';
+	const pages = [
+		'basic/overview', 'basic/setup', 'basic/routing', 'basic/status',
+		'advanced/overview', 'advanced/service', 'advanced/certificates', 'advanced/routing'
+	];
+
+	assert.strictEqual(menu[root].action.type, 'firstchild');
+	assert.strictEqual(menu[root + '/basic'].action.type, 'firstchild');
+	assert.strictEqual(menu[root + '/advanced'].action.type, 'firstchild');
+	pages.forEach(function(page) {
+		assert.strictEqual(menu[root + '/' + page].action.type, 'view');
+		assert.strictEqual(menu[root + '/' + page].action.path, 'xray-mitm/overview');
+	});
 }
 
 testPasswallSelection();
@@ -169,4 +197,5 @@ testSimpleState();
 testRoutingArguments();
 testRouteStatusAndProgress();
 testOverviewLoadsAndRendersWithLuCIStateDependency();
+testRoutedPageMenu();
 console.log('Frontend state tests passed.');

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -150,13 +150,16 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	const fakeDocument = { createTextNode: function(value) { return value; } };
 	const fakeLuCI = {
 		bind: function(fn, context) { return fn.bind(context); },
-		env: { dispatchpath: [ 'admin', 'services', 'xray-mitm', 'basic', 'overview' ] },
 		url: function(value) { return '/' + value; }
 	};
 	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
 
 	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
 		'LuCI modules must use loader directives instead of CommonJS require()');
+	assert.match(overviewSource, /var PROJECT_VERSION = '0\.4\.2';/,
+		'LuCI dashboard keeps the current project version fallback');
+	assert.match(overviewSource, /xray-mitm-version-badge/,
+		'LuCI dashboard renders a visible application version badge');
 
 	const overview = loadLuciModule(overviewSource, modules, {
 		E: fakeElement,
@@ -168,28 +171,84 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 	assert.doesNotThrow(function() {
 		overview.renderSetupGuide({ configured: false, running: false }, {}, {});
 	});
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'basic', page: 'overview' });
-	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'certificates' ];
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'certificates' });
-	fakeLuCI.env.dispatchpath = [ 'admin', 'services', 'xray-mitm', 'advanced', 'unknown' ];
-	assert.deepStrictEqual(overview.routeContext(), { mode: 'advanced', page: 'overview' });
+	assert.strictEqual(typeof overview.switchDashboardPage, 'function');
 }
 
-function testRoutedPageMenu() {
+function testSingleViewMenu() {
 	const menu = JSON.parse(fs.readFileSync(menuPath, 'utf8'));
 	const root = 'admin/services/xray-mitm';
-	const pages = [
-		'basic/overview', 'basic/setup', 'basic/routing', 'basic/status',
-		'advanced/overview', 'advanced/service', 'advanced/certificates', 'advanced/routing'
-	];
 
-	assert.strictEqual(menu[root].action.type, 'firstchild');
-	assert.strictEqual(menu[root + '/basic'].action.type, 'firstchild');
-	assert.strictEqual(menu[root + '/advanced'].action.type, 'firstchild');
-	pages.forEach(function(page) {
-		assert.strictEqual(menu[root + '/' + page].action.type, 'view');
-		assert.strictEqual(menu[root + '/' + page].action.path, 'xray-mitm/overview');
+	assert.deepStrictEqual(Object.keys(menu), [ root ]);
+	assert.strictEqual(menu[root].action.type, 'view');
+	assert.strictEqual(menu[root].action.path, 'xray-mitm/overview');
+}
+
+function testClientSideDashboardTabs() {
+	function node(attributes) {
+		return {
+			attributes: attributes || {},
+			style: {},
+			className: '',
+			getAttribute: function(name) { return this.attributes[name]; }
+		};
+	}
+
+	const simple = node();
+	const advanced = node();
+	const panels = [
+		node({ 'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'overview' }),
+		node({ 'data-dashboard-panel-mode': 'basic', 'data-dashboard-panel-page': 'routing' }),
+		node({ 'data-dashboard-panel-mode': 'advanced', 'data-dashboard-panel-page': 'overview' }),
+		node({ 'data-dashboard-panel-mode': 'advanced', 'data-dashboard-panel-page': 'service' })
+	];
+	const rows = [
+		node({ 'data-dashboard-tabs': 'mode' }),
+		node({ 'data-dashboard-tabs': 'basic' }),
+		node({ 'data-dashboard-tabs': 'advanced' })
+	];
+	const tabs = [
+		node({ 'data-dashboard-tab-mode': 'mode', 'data-dashboard-tab-page': 'basic' }),
+		node({ 'data-dashboard-tab-mode': 'mode', 'data-dashboard-tab-page': 'advanced' }),
+		node({ 'data-dashboard-tab-mode': 'basic', 'data-dashboard-tab-page': 'overview' }),
+		node({ 'data-dashboard-tab-mode': 'advanced', 'data-dashboard-tab-page': 'service' })
+	];
+	const fakeDocument = {
+		createTextNode: function(value) { return value; },
+		getElementById: function(id) {
+			return id === 'xray-mitm-simple' ? simple :
+				(id === 'xray-mitm-advanced' ? advanced : null);
+		},
+		querySelectorAll: function(selector) {
+			return selector === '[data-dashboard-panel-mode]' ? panels :
+				(selector === '[data-dashboard-tabs]' ? rows : tabs);
+		}
+	};
+	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
+	const overview = loadLuciModule(overviewSource, {
+		view: { extend: function(methods) { return methods; } },
+		rpc: { declare: function() { return function() {}; } },
+		ui: { addNotification: function() {}, createHandlerFn: function() { return function() {}; } },
+		dom: { content: function() {} },
+		'xray-mitm.state': {}
+	}, {
+		E: function() {},
+		_: function(value) { return value; },
+		document: fakeDocument,
+		L: { bind: function(fn, context) { return fn.bind(context); } }
 	});
+
+	overview.switchDashboardPage('mode', 'advanced');
+	assert.strictEqual(simple.style.display, 'none');
+	assert.strictEqual(advanced.style.display, '');
+	assert.strictEqual(rows[1].style.display, 'none');
+	assert.strictEqual(rows[2].style.display, '');
+	assert.strictEqual(panels[2].style.display, '');
+	assert.strictEqual(tabs[1].className, 'cbi-tab');
+
+	overview.switchDashboardPage('advanced', 'service');
+	assert.strictEqual(panels[2].style.display, 'none');
+	assert.strictEqual(panels[3].style.display, '');
+	assert.strictEqual(tabs[3].className, 'cbi-tab');
 }
 
 testPasswallSelection();
@@ -197,5 +256,6 @@ testSimpleState();
 testRoutingArguments();
 testRouteStatusAndProgress();
 testOverviewLoadsAndRendersWithLuCIStateDependency();
-testRoutedPageMenu();
+testSingleViewMenu();
+testClientSideDashboardTabs();
 console.log('Frontend state tests passed.');


### PR DESCRIPTION
## What changed

Describe the concrete problem and resulting behavior.

## Validation

- [ ] `sh scripts/validate-release.sh` passes locally.
- [ ] `git diff --check` passes.
- [ ] `CHANGELOG.md` has a user-facing entry under `Unreleased`, or this change has no user-facing effect.
- [ ] Relevant AX4200 behavior was tested, or router testing does not apply.
- [ ] Every affected LuCI page was loaded and exercised in a local browser against
      the lab router, with no error notification, blank view, or new console error;
      or this change cannot affect LuCI.
- [ ] The project owner visually reviewed and explicitly approved the exact tested
      UI candidate, or this change cannot affect the UI.
- [ ] Existing CA material, service state, and PassWall2 routing were preserved unless intentionally changed.
- [ ] No private keys, credentials, router configurations, backups, or generated packages are included.

Include concise commands and results for the checks that apply.
