### PR TITLE
Refresh README and advanced documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Rewrite the English and Persian README files as concise beginner-first guides,
+  and add separate advanced-usage and security references.
 - Replace the long Basic and Advanced dashboards with PassWall2-style tabs.
   Switching tabs is immediate and shows only the selected section without
   reloading the LuCI page.

--- a/README.fa.md
+++ b/README.fa.md
@@ -1,21 +1,36 @@
-# راه‌اندازی Xray MITM Domain Fronting روی OpenWrt
+# Xray MITM Domain Fronting برای OpenWrt
 
-**راهنما:** [English](README.md) | فارسی
+**نسخه:** `v0.4.2` · **راهنما:** [English](README.md) | فارسی · **پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
 
-**پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
+این پروژه سرویس مستقل Xray MITM-DomainFronting، داشبورد LuCI و مسیریابی اختیاری PassWall2 را برای روترهای رسمی OpenWrt 25.12 که از APK استفاده می‌کنند فراهم می‌کند.
 
-این پروژه سرویس مستقل Xray MITM-DomainFronting، صفحه مدیریتی LuCI و اتصال اختیاری به مسیریابی PassWall2 را برای OpenWrt رسمی سری 25.12 فراهم می‌کند.
+برای بیشتر کاربران:
+
+1. با یک دستور نصب یا به‌روزرسانی کنید.
+2. در LuCI به **Services → MITM Domain Fronting** بروید.
+3. در بخش **Basic** گزینه **Set up automatically** را انتخاب کنید.
+4. گواهی عمومی را دانلود و مورد اعتماد کنید.
+5. VPN موجود را انتخاب و مسیریابی پیشنهادی را بررسی کنید.
+6. مسیریابی را اعمال و **Run check** را اجرا کنید.
 
 > [!CAUTION]
-> CA مورد اعتماد MITM می‌تواند ترافیک HTTPS دستگاه‌هایی را که به آن اعتماد دارند رمزگشایی کند. فقط روی شبکه و دستگاه‌هایی استفاده کنید که مالک آن‌ها هستید یا اجازه مدیریتشان را دارید. فقط `mycert.crt` را روی کلاینت نصب کنید. `mycert.key` باید روی روتر و در نسخه پشتیبان محافظت‌شده بماند.
+> نرم‌افزار MITM می‌تواند ترافیک HTTPS دستگاه‌هایی را که به گواهی آن اعتماد دارند رمزگشایی کند. فقط در شبکه و دستگاه‌هایی استفاده کنید که مالک آن‌ها هستید یا اجازه مدیریتشان را دارید. فقط `mycert.crt` را روی کلاینت نصب کنید. `mycert.key` باید روی روتر و در نسخه‌های پشتیبان محافظت‌شده باقی بماند.
 
-## از اینجا شروع کنید
+## نیازمندی‌ها
 
-feed عمومی فعلی برای OpenWrt رسمی **نسخه 25.12.5 و نسخه‌های نگهداری جدیدتر از سری 25.12** است. روتر باید از مدیر بسته `apk` استفاده کند و به GitHub و GitHub Pages دسترسی داشته باشد.
+- OpenWrt رسمی 25.12.5 یا یکی از نسخه‌های نگهداری بعدی سری 25.12، همراه با `apk` و LuCI.
+- دسترسی روتر به GitHub و GitHub Pages.
+- PassWall2 برای مسیریابی خودکار؛ خود سرویس MITM به PassWall2 نیاز ندارد.
+- یک پروفایل shunt فعال و یک VPN سالم در PassWall2 برای سرویس‌هایی که باید از VPN عبور کنند.
 
-### ۱. نصب یا به‌روزرسانی با یک دستور
+## سازگاری
 
-اگر آدرس روتر متفاوت است، `192.168.1.1` را تغییر دهید. وقتی درخواست شد رمز روتر را وارد کنید.
+- OpenWrt رسمی 25.12.x با بسته‌های APK: `xray-mitm` و `luci-app-xray-mitm`.
+- سخت‌افزار آزمایش‌شده: ASUS TUF-AX4200. سخت‌افزارهای دیگر ممکن است کار کنند، اما در فهرست آزمایش‌شده نیستند.
+
+## نصب یا به‌روزرسانی
+
+همین دستور برای نصب اولیه و به‌روزرسانی‌های بعدی استفاده می‌شود. اگر آدرس روتر متفاوت است، `192.168.1.1` را تغییر دهید.
 
 **MAC:**
 
@@ -29,7 +44,7 @@ ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.
 ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
-اگر از قبل با SSH داخل روتر هستید:
+اگر از قبل داخل SSH روتر هستید:
 
 **ROUTER:**
 
@@ -37,242 +52,90 @@ ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.git
 wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-دستور، فایل نصب‌کننده عمومی را پیش از اجرا بررسی می‌کند. SHA-256 ثابت آن `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405` است.
+نصب‌کننده نسخه OpenWrt، checksum نصب‌کننده و feed امضاشده را بررسی می‌کند، نسخه پشتیبان محافظت‌شده می‌سازد و فقط بسته‌های پروژه را نصب یا به‌روزرسانی می‌کند. PassWall2 نصب نمی‌شود، گواهی ساخته نمی‌شود، MITM روشن نمی‌شود و مسیریابی تغییر نمی‌کند.
 
-همین دستور هم نصب اولیه و هم به‌روزرسانی‌های بعدی را انجام می‌دهد. نصب‌کننده:
+SHA-256 ثابت نصب‌کننده این است: `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
 
-1. نسخه OpenWrt و مدیر بسته را بررسی می‌کند.
-2. کلید عمومی feed را با HTTPS دریافت می‌کند.
-3. فقط در صورت تطبیق دقیق fingerprint زیر، کلید را می‌پذیرد:
+بعد از پایان، LuCI را با **HTTPS** در مسیر **Services → MITM Domain Fronting** باز کنید.
 
-   ```text
-   3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
-   ```
+## راه‌اندازی اولیه
 
-4. feed امضاشده را به APK اضافه و فایل‌های آن را برای ارتقای firmware نگه می‌دارد.
-5. داخل `/root/` یک نسخه پشتیبان محافظت‌شده می‌سازد.
-6. از APK می‌خواهد امضا را بررسی و فقط بسته‌های `xray-mitm` و `luci-app-xray-mitm` را نصب یا به‌روزرسانی کند.
+این روند برای نصب تازه است. به‌روزرسانی تنظیمات، گواهی فعال، وضعیت سرویس و مسیریابی PassWall2 را حفظ می‌کند؛ فقط اگر LuCI چیزی را ناقص اعلام کرد راه‌اندازی را تکرار کنید.
 
-نصب‌کننده از `--allow-untrusted` استفاده نمی‌کند، همه بسته‌های روتر را یک‌جا ارتقا نمی‌دهد، CA نمی‌سازد، سرویس را روشن نمی‌کند و مسیریابی PassWall2 را تغییر نمی‌دهد.
+### ۱. آماده‌سازی روتر
 
-### ۲. راه‌اندازی اولیه در LuCI
+در **Basic → Setup** گزینه **Set up automatically** را انتخاب کنید.
 
-LuCI را با **HTTPS** باز کنید و به **Services → MITM Domain Fronting** بروید.
+این گزینه پیکربندی پیش‌فرض را در صورت نیاز آماده می‌کند، گواهی را در صورت نیاز می‌سازد و فعال می‌کند، MITM را روشن می‌کند و شروع خودکار بعد از راه‌اندازی مجدد را فعال می‌کند. پیکربندی و گواهی معتبر موجود را حفظ می‌کند و PassWall2 را نصب نمی‌کند.
 
-این بخش فقط برای نصب تازه است. اگر در حال به‌روزرسانی نصب موجود هستید،
-این بخش را تکرار نکنید؛ به‌روزرسانی تنظیمات، CA فعال، وضعیت سرویس و مسیریابی
-PassWall2 را حفظ می‌کند. در این حالت راهنما به‌جای **First-time setup**،
-**System overview** را نشان می‌دهد و فقط موارد ناقص را درخواست می‌کند.
+### ۲. دانلود و اعتماد به گواهی عمومی
 
-برای مسیر ساده، در نمای **Simple** گزینه **Set up automatically** را انتخاب
-کنید. این گزینه در صورت نیاز پیکربندی بسته را نصب می‌کند، در صورت نیاز CA را
-می‌سازد و فعال می‌کند، MITM را روشن می‌کند و شروع خودکار پس از راه‌اندازی را
-فعال می‌کند. پیکربندی یا CA معتبر موجود را جایگزین نمی‌کند.
+در **Basic → Setup** گزینه **Download public certificate** را انتخاب کنید. فقط `mycert.crt` را روی دستگاه‌هایی نصب کنید که باید از MITM استفاده کنند؛ کلید خصوصی روی روتر باقی می‌ماند.
 
-بعد از راه‌اندازی خودکار:
+- **macOS:** گواهی را باز کنید، به Keychain Access اضافه کنید و **Always Trust** را فعال کنید.
+- **Windows:** گواهی را باز کنید، **Install Certificate** را بزنید و آن را در **Trusted Root Certification Authorities** قرار دهید.
+- **Android:** تنظیمات Security را باز کنید، **Install a certificate** را انتخاب کنید و آن را به‌عنوان CA certificate نصب کنید.
 
-1. فقط `mycert.crt` را دانلود کنید.
-2. `mycert.crt` را روی کلاینت‌هایی که باید از MITM استفاده کنند به‌عنوان Root CA مورد اعتماد نصب کنید.
-3. Health check را اجرا کنید و مطمئن شوید نتیجه PASS است.
-4. اگر مسیریابی انتخابی لازم دارید، به بخش PassWall2 در پایین بروید.
+نام منوها ممکن است در نسخه‌های مختلف سیستم‌عامل فرق کند. Firefox ممکن است از مخزن گواهی جداگانه استفاده کند. بعضی برنامه‌های native به گواهی نصب‌شده توسط کاربر اعتماد نمی‌کنند یا certificate pinning دارند؛ ابتدا مرورگر را آزمایش کنید.
 
-اگر نمای **Advanced settings** را انتخاب کردید، ترتیب دستی معادل این است:
-نصب پیکربندی پیش‌فرض، ساختن یا وارد کردن گواهی و کلید خصوصی منطبق به‌عنوان
-candidate، فعال‌کردن candidate، روشن‌کردن سرویس، اجرای health check و فعال‌کردن
-شروع خودکار. `mycert.key` را هرگز روی کلاینت کپی نکنید.
+### ۳. تنظیم مسیریابی پیشنهادی
 
-CA عمومی را برای کاربر فعلی نصب کنید:
+اگر به مسیریابی PassWall2 نیاز ندارید، این مرحله را رد کنید. در غیر این صورت به **Basic → Routing** بروید و این موارد را انتخاب کنید:
 
-**MAC:**
+- **Main routing profile** — پروفایل shunt که در PassWall2 فعال است.
+- **Working VPN connection** — یک VPN موجود که از قبل کار می‌کند.
 
-```sh
-security add-trusted-cert -r trustRoot \
-  -k "$HOME/Library/Keychains/login.keychain-db" ./mycert.crt
-```
+گزینه **Review selected routing** را بزنید، مقصدها را بررسی کنید و سپس **Apply recommended routing** را انتخاب کنید. مقصدهای MITM به سرویس روشن نیاز دارند؛ در صورت نیاز آن را از **Advanced → Service** روشن کنید. دستیار preview را بررسی و قوانین نامرتبط PassWall2 را حفظ می‌کند.
 
-**WINDOWS PC (PowerShell):**
+### ۴. بررسی عملکرد
 
-```powershell
-certutil.exe -user -addstore -f Root .\mycert.crt
-```
+به **Basic → Status** بروید و **Run check** را انتخاب کنید. این بررسی سرویس MITM روی روتر را آزمایش می‌کند و ثابت نمی‌کند که همه کلاینت‌ها به `mycert.crt` اعتماد دارند.
 
-ممکن است Firefox از certificate store جدا استفاده کند؛ در این حالت `mycert.crt` را داخل Firefox هم وارد کنید. `mycert.key` را هرگز روی کلاینت کپی نکنید.
+بعد از موفقیت، وب‌سایت‌ها را با مرورگر کلاینت آزمایش کنید. سایت MITM باید `MITM-DomainFronting` را به‌عنوان issuer نشان دهد؛ سایت VPN یا direct باید مرجع گواهی عمومی عادی خود را نشان دهد.
 
-### ۳. مسیریابی دامنه‌های انتخابی با PassWall2
+## مسیریابی پیشنهادی
 
-اگر فقط SOCKS محلی را می‌خواهید، این مرحله را رد کنید.
+مدل پیش‌فرض بر اساس هدف ترافیک است:
 
-1. بخش PassWall2 را در صفحه LuCI پروژه باز کنید.
-2. shunt node و VPN node موجود را انتخاب کنید.
-3. اگر سرویس MITM را انتخاب می‌کنید، مطمئن شوید سرویس در وضعیت running است.
-   دستیار previewای را که ترافیک را به SOCKS محلی متوقف می‌فرستد اجازه نمی‌دهد.
-4. **Review selected routing** یا **Preview changes** را بزنید.
-5. node محلی، دامنه‌ها، مقصدها و ترتیب قوانین را بررسی کنید.
-6. فقط وقتی preview درست است **Apply preview** را انتخاب کنید.
+| ترافیک | مقصد | هدف |
+| --- | --- | --- |
+| سرویس‌های Google | MITM | استفاده از سرویس MITM محلی برای گروه انتخاب‌شده Google. |
+| اپلیکیشن و API جمنای | VPN انتخاب‌شده | عبور ترافیک Gemini از VPN سالم. |
+| وب‌سایت‌ها و IPهای ایران | Direct | عبور مستقیم ترافیک محلی انتخاب‌شده بدون VPN و MITM. |
 
-دستیار حداکثر سه قانون مدیریت‌شده می‌سازد و آن‌ها را به این ترتیب قرار می‌دهد:
+گروه‌های اختیاری در **Basic → Routing** قرار دارند:
 
-1. **VPN Overrides** بسته‌های انتخابی Gemini، بررسی اتصال Android، کنترل YouTube و ورود Google Account را به VPN انتخاب‌شده می‌فرستد. دامنه تحویل ویدئو یعنی `googlevideo.com` عمداً در این قانون نیست.
-2. **MITM-Compatible Services** بسته‌های انتخابی Google، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را به SOCKS محلی `127.0.0.1:10808` می‌فرستد. Google پیشنهاد پیش‌فرض است؛ Meta و Fastly تا زمان آزمایش روی دستگاه‌های شما خاموش می‌مانند.
-3. **Regional Direct Access** دامنه‌ها و IPهای ایران را مستقیم می‌فرستد.
+- **VPN Overrides** می‌تواند بررسی اتصال Android، ورود و کنترل‌های YouTube و ورود به حساب Google را شامل شود. `googlevideo.com` عمداً خارج است تا تحویل ویدئوی YouTube بتواند از MITM استفاده کند.
+- **MITM-Compatible Services** می‌تواند گروه‌های Google، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را شامل شود. ابتدا Google را آزمایش کنید و قبل از اتکا به برنامه‌های native، Meta و Fastly را جداگانه آزمایش کنید.
+- **Regional Direct Access** از گروه‌های دامنه و IP ایران استفاده می‌کند.
 
-هر checkbox فقط یک مجموعه دامنه را به یکی از همین سه قانون اضافه می‌کند و قانون جداگانه‌ای نمی‌سازد. اولین اعمال مدل سه‌قانونی، قوانین قدیمی مدیریت‌شده توسط بسته را مهاجرت می‌دهد. قوانین قدیمی ساخته‌شده توسط کاربر بدون تغییر باقی می‌مانند، ولی اتصال آن‌ها به shunt انتخابی حذف می‌شود تا تطبیق تکراری رخ ندهد. برای جلوگیری از loop، مقدار `localhost_proxy=0` را نگه دارید.
+هر checkbox یک گروه سرویس را داخل یکی از این انتساب‌ها فعال می‌کند و قانون جداگانه نمی‌سازد. بیشتر کاربران می‌توانند انتخاب‌های پیشنهادی را بدون تغییر نگه دارند.
 
-### ۴. بررسی از دستگاه کلاینت
+## به‌روزرسانی
 
-**MAC:**
+همان دستور نصب را دوباره اجرا کنید. به‌روزرسانی تنظیمات، گواهی فعال، وضعیت سرویس و مسیریابی PassWall2 را حفظ می‌کند. سپس LuCI را reload کنید و کارت‌های وضعیت را ببینید؛ تا وقتی LuCI درخواست نکرده گواهی جدید نسازید یا راه‌اندازی اولیه را تکرار نکنید.
 
-```sh
-for url in \
-  https://www.google.com \
-  https://www.youtube.com \
-  https://www.cloudflare.com \
-  https://gemini.google.com
-do
-  printf '\n%s\n' "$url"
-  curl -Iv --max-time 20 "$url" 2>&1 |
-    grep -E 'issuer:|^HTTP/'
-done
-```
+## مشکلات رایج
 
-**WINDOWS PC (PowerShell):**
+- **PassWall2 شناسایی نمی‌شود:** MITM می‌تواند اجرا شود، اما مسیریابی خودکار به PassWall2 نیاز دارد. آن را نصب و فعال کنید و LuCI را reload کنید.
+- **VPN یا پروفایل مسیریابی پیدا نشد:** یک VPN یا پروفایل shunt سالم در PassWall2 بسازید و به **Basic → Routing** برگردید.
+- **مسیرهای MITM کار نمی‌کنند:** در **Advanced → Service** روشن بودن MITM و اعتماد کلاینت به `mycert.crt` را بررسی کنید.
+- **خطای certificate:** فقط `mycert.crt` فعلی را نصب کنید و هرگز `mycert.key` را کپی نکنید؛ وضعیت گواهی را در **Advanced → Certificates** بررسی کنید.
+- **برنامه native کار نمی‌کند:** بعضی برنامه‌ها CA کاربر را نمی‌پذیرند، certificate pinning دارند یا خارج از گروه انتخاب‌شده کار می‌کنند. ابتدا مرورگر را بررسی کنید.
 
-```powershell
-$urls = @(
-  'https://www.google.com',
-  'https://www.youtube.com',
-  'https://www.cloudflare.com',
-  'https://gemini.google.com'
-)
+## بخش Advanced
 
-foreach ($url in $urls) {
-  Write-Host "`n$url"
-  curl.exe -Iv --max-time 20 $url 2>&1 |
-    Select-String -Pattern 'issuer:', 'HTTP/'
-}
-```
+بیشتر کاربران به مرجع فنی نیاز ندارند. جزئیات چرخه گواهی، کنترل دستی سرویس، مسیریابی سفارشی، rollback، recovery، SOCKS محلی و فرمان‌های CLI در این فایل‌هاست:
 
-دامنه‌ای که از MITM عبور می‌کند باید این issuer را نشان دهد:
-
-```text
-issuer: CN=MITM-DomainFronting
-```
-
-دامنه‌های VPN یا direct باید CA عمومی عادی خود را نشان دهند. پاسخ HTTP دامنه‌های مورد انتظار نیز باید موفق باشد.
-
-## به‌روزرسانی‌های بعدی
-
-ساده‌ترین روش، اجرای دوباره همان دستور نصب یک‌خطی است. بعد از تنظیم feed می‌توانید مستقیماً روی روتر نیز به‌روزرسانی کنید:
-
-**ROUTER:**
-
-```sh
-apk update
-apk upgrade xray-mitm luci-app-xray-mitm
-```
-
-این دستور فقط همین دو بسته انتخاب‌شده و وابستگی‌های لازم آن‌ها را ارتقا می‌دهد. از اجرای `apk upgrade` بدون نام بسته‌ها به‌عنوان جایگزین ارتقای firmware استفاده نکنید.
-
-به‌روزرسانی، `/etc/config/xray-mitm`، پوشه `/etc/xray-mitm/`، CA فعال، وضعیت سرویس و تنظیمات PassWall2 را حفظ می‌کند. قبل از تغییر feed یا بسته‌ها، نصب‌کننده فایل پشتیبان `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` را با سطح دسترسی `0600` می‌سازد.
-
-بعد از به‌روزرسانی، LuCI را دوباره بارگذاری و کارت‌های وضعیت را بررسی کنید.
-ساختن CA جدید یا اجرای دوباره راه‌اندازی اولیه لازم نیست، مگر اینکه صفحه
-اعلام کند پیکربندی یا وضعیت گواهی وجود ندارد یا نیاز به بررسی دارد.
-
-## روش احراز اصالت
-
-در اجرای اول، نصب‌کننده با HTTPS از GitHub دریافت می‌شود و fingerprint کلید عمومی feed را در خود دارد. APK با این کلید، امضای index و همه بسته‌ها را بررسی می‌کند. به‌روزرسانی‌های بعدی نیز از همان کلید ذخیره‌شده و feed امضاشده استفاده می‌کنند.
-
-- build عادی pull request هیچ secretی ندارد و فقط artifact توسعه‌ای بدون کلید امضای production و بدون secret می‌سازد.
-- tag انتشار باید دقیقاً با نسخه بسته یکی باشد.
-- امضای production فقط در GitHub environment محافظت‌شده `signed-feed` انجام می‌شود.
-- workflow ابتدا تطبیق کلید خصوصی محافظت‌شده با کلید عمومی commit‌شده را بررسی می‌کند.
-- SDK رسمی OpenWrt فایل `packages.adb` و APKهای امضاشده را می‌سازد.
-- feed در GitHub Pages و فایل‌های همان نسخه در GitHub Release منتشر می‌شوند.
-
-کلید خصوصی production داخل repository یا package قرار نمی‌گیرد. جزئیات انتشار، بازیابی و تعویض کلید در [راهنمای عملیات feed امضاشده](docs/SIGNED_FEED.md) آمده است.
-
-## نیازمندی‌ها و رفتار امن
-
-بسته‌ها `all` هستند، ولی feed فعلی برای اکوسیستم APK در OpenWrt 25.12 آزمایش می‌شود. نصب اولیه عمداً غیرفعال است: CA ساخته نمی‌شود، startup فعال نمی‌شود، Xray اجرا نمی‌شود و firewall، DNS و PassWall2 تغییر نمی‌کنند.
-
-listenerها فقط روی localhost هستند:
-
-| کاربرد | آدرس |
-| --- | --- |
-| ورودی محلی mixed/SOCKS | `127.0.0.1:10808` |
-| تونل رمزگشایی TLS برای HTTP/1.1 | `127.0.0.1:11666` |
-| تونل رمزگشایی TLS برای HTTP/2 | `127.0.0.1:11777` |
-
-## نصب دستی احرازشده
-
-اگر روتر به GitHub Pages دسترسی ندارد، دو APK، فایل `xray-mitm-feed-v1.pem`، فایل `PUBLIC_KEY_SHA256` و `SHA256SUMS` را از یک GitHub Release امضاشده واحد روی مک یا ویندوز دریافت کنید.
-
-**ROUTER:**
-
-```sh
-mkdir -p -m 0700 /tmp/xray-mitm-install
-```
-
-**MAC:**
-
-```sh
-cd "/path/to/downloaded/release-files"
-scp -O xray-mitm-*.apk luci-app-xray-mitm-*.apk \
-  xray-mitm-feed-v1.pem PUBLIC_KEY_SHA256 SHA256SUMS \
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-**WINDOWS PC (PowerShell):**
-
-```powershell
-Set-Location "C:\path\to\downloaded\release-files"
-scp.exe -O .\xray-mitm-*.apk .\luci-app-xray-mitm-*.apk `
-  .\xray-mitm-feed-v1.pem .\PUBLIC_KEY_SHA256 .\SHA256SUMS `
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-قبل از نصب کلید، fingerprint را با مقدار این README مقایسه کنید. اگر متفاوت بود ادامه ندهید.
-
-**ROUTER:**
-
-```sh
-cd /tmp/xray-mitm-install
-printf '%s  %s\n' \
-  '3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a' \
-  'xray-mitm-feed-v1.pem' | sha256sum -c -
-awk '$2 ~ /[.]apk$/' SHA256SUMS | sha256sum -c -
-mkdir -p /etc/apk/keys
-cp xray-mitm-feed-v1.pem /etc/apk/keys/xray-mitm-feed-v1.pem
-chmod 0644 /etc/apk/keys/xray-mitm-feed-v1.pem
-apk add ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
-```
-
-artifactهای توسعه‌ای CI خارج از مسیر اعتماد production هستند و نباید به‌عنوان انتشار امضاشده به کاربر تازه‌کار داده شوند.
-
-## آزمایش توسعه و انتشار
-
-برای روند branch محلی و pull request، [راهنمای مشارکت](CONTRIBUTING.md) و برای
-تاریخچه تغییرات قابل مشاهده کاربران، [فهرست تغییرات](CHANGELOG.md) را ببینید.
-
-**MAC:**
-
-```sh
-cd "/path/to/xray-mitm-openwrt"
-sh scripts/validate-release.sh
-```
-
-**WINDOWS PC (PowerShell with WSL):**
-
-```powershell
-wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
-```
-
-قبل از انتشار tag، [راهنمای آزمایش انتشار](docs/RELEASE_TESTING.md) را اجرا کنید.
+- [راهنمای پیشرفته](docs/ADVANCED.md)
+- [امنیت](SECURITY.md)
+- [عملیات feed امضاشده](docs/SIGNED_FEED.md)
+- [آزمایش انتشار](docs/RELEASE_TESTING.md)
+- [روند مشارکت و توسعه](CONTRIBUTING.md)
 
 ## حذف
 
-ابتدا سرویس را متوقف و startup را غیرفعال کنید. اگر مسیریابی PassWall2 اعمال شده، rollback را از LuCI اجرا کنید. سپس:
+اگر مسیریابی اعمال شده است، ابتدا آن را از LuCI rollback کنید. سپس روی روتر:
 
 **ROUTER:**
 
@@ -282,6 +145,8 @@ wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
 apk del luci-app-xray-mitm xray-mitm
 ```
 
-بعد از پایان استفاده، `mycert.crt` را از trust store همه کلاینت‌ها حذف کنید. `mycert.key` و نسخه‌های پشتیبان روتر همچنان محرمانه هستند.
+بعد از پایان استفاده، `mycert.crt` را از trust store کلاینت‌ها حذف کنید. نسخه‌های پشتیبان و `mycert.key` همچنان محرمانه هستند.
 
-این پروژه مستقل از Xray-core، OpenWrt، LuCI و PassWall2 است. مجوزها و attribution در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) آمده است.
+## انتساب
+
+پیکربندی domain-fronting بسته از [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23) گرفته شده و تحت مجوز GPL-3.0 است. Xray-core، OpenWrt، LuCI و PassWall2 پروژه‌های upstream جداگانه هستند. به [اعلان‌های third-party](THIRD_PARTY_NOTICES.md) مراجعه کنید.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,36 @@
 # Xray MITM Domain Fronting for OpenWrt
 
-**Instructions:** English | [فارسی](README.fa.md)
+**Version:** `v0.4.2` · **Instructions:** English | [فارسی](README.fa.md) · **Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
 
-**Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
+This project adds a standalone Xray MITM-DomainFronting service, a LuCI dashboard, and optional PassWall2 routing to official OpenWrt 25.12 APK-based routers.
 
-This project packages a standalone Xray MITM-DomainFronting service, a LuCI management page, and optional PassWall2 routing for official OpenWrt 25.12 APK-based routers.
+For most users:
+
+1. Install or update with one command.
+2. Open LuCI and go to **Services → MITM Domain Fronting**.
+3. In **Basic**, select **Set up automatically**.
+4. Download and trust the public certificate.
+5. Choose your existing VPN and review the recommended routing.
+6. Apply the routing and select **Run check**.
 
 > [!CAUTION]
-> A trusted MITM certificate authority can decrypt HTTPS traffic from devices that trust it. Use it only on networks and devices you own or are authorized to manage. Install only `mycert.crt` on clients. Keep `mycert.key` on the router and in protected backups.
+> MITM software can decrypt HTTPS traffic from devices that trust its certificate. Use it only on networks and devices you own or are authorized to manage. Install only `mycert.crt` on clients. Keep `mycert.key` on the router and in protected backups.
 
-## Start here
+## Requirements
 
-The supported public feed currently targets official OpenWrt **25.12.5 and later 25.12 maintenance releases**. The router must use the `apk` package manager and have internet access to GitHub and GitHub Pages.
+- Official OpenWrt 25.12.5 or a later 25.12 maintenance release, with `apk` and LuCI.
+- Internet access from the router to GitHub and GitHub Pages.
+- PassWall2 for automatic routing. It is not required for the MITM service itself.
+- A working PassWall2 shunt profile and VPN node for VPN-routed services.
 
-### 1. Install or update with one command
+## Compatibility
 
-Replace `192.168.1.1` if your router uses another address. Enter the router password when asked.
+- Official OpenWrt 25.12.x using APK packages: `xray-mitm` and `luci-app-xray-mitm`.
+- Tested hardware: ASUS TUF-AX4200. Other hardware may work, but is not on the tested list.
+
+## Install or update
+
+The same command is used for a first installation and later updates. Replace `192.168.1.1` if your router uses another address.
 
 **MAC:**
 
@@ -29,256 +44,96 @@ ssh root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.
 ssh.exe root@192.168.1.1 'wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf "%s  %s\n" "8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405" "/tmp/install-xray-mitm.sh" | sha256sum -c - && sh /tmp/install-xray-mitm.sh'
 ```
 
-If you are already connected through SSH:
-
-**ROUTER:**
+**ROUTER** if you are already connected through SSH:
 
 ```sh
 wget -qO /tmp/install-xray-mitm.sh https://duuuude.github.io/xray-mitm-openwrt/install.sh && printf '%s  %s\n' '8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405' '/tmp/install-xray-mitm.sh' | sha256sum -c - && sh /tmp/install-xray-mitm.sh
 ```
 
-The command verifies the public installer before running it. Its pinned SHA-256 is `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
+The installer checks the OpenWrt release, verifies the installer checksum and signed feed, creates a protected backup, and updates only the project packages. It does not install PassWall2, create a certificate, start MITM, or change routing.
 
-The same command handles first installation and later updates. It:
+The pinned installer SHA-256 is `8af96edc133c01a7e9d0a8f4673b7225c47322d73874c05a9c4a0133f3058405`.
 
-1. Checks the OpenWrt release and package manager.
-2. Downloads the project feed public key over HTTPS.
-3. Requires this exact SHA-256 fingerprint before trusting the key:
+When it finishes, open LuCI over **HTTPS** at **Services → MITM Domain Fronting**.
 
-   ```text
-   3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
-   ```
+## First-time setup
 
-4. Adds the signed feed to APK and preserves the feed configuration across firmware upgrades.
-5. Makes a protected backup under `/root/`.
-6. Lets APK verify and install or update `xray-mitm` and `luci-app-xray-mitm` by package name.
+This flow is for a fresh installation. Updates preserve the configuration, active certificate, service state, and PassWall2 routing; repeat setup only if LuCI reports that something is missing.
 
-The installer never uses `--allow-untrusted`, never upgrades every package on the router, and does not create a CA, start the service, or change PassWall2 routing.
+### 1. Set up the router
 
-### 2. Complete first-time setup in LuCI
+In **Basic → Setup**, select **Set up automatically**.
 
-Open LuCI over **HTTPS**, then go to **Services → MITM Domain Fronting**.
+This prepares the default configuration when needed, creates and activates a certificate when needed, starts MITM, and enables startup after reboot. It preserves a valid existing configuration and certificate and does not install PassWall2.
 
-This section is for a new installation. If you are updating an existing
-installation, skip it: updates preserve the configuration, active CA, service
-state, and PassWall2 routing. The setup guide will show **System overview**
-and only ask you to complete items that are not ready.
+### 2. Download and trust the public certificate
 
-For the beginner path, stay in **Simple** view and select **Set up
-automatically**. It installs the packaged configuration when needed,
-generates and activates a CA when needed, starts MITM, and enables automatic
-startup. It does not replace an existing valid configuration or CA.
+In **Basic → Setup**, select **Download public certificate**. Install only `mycert.crt` on devices that should use MITM; the private key stays on the router.
 
-After automatic setup:
+- **macOS:** open it, add it to Keychain Access, and set it to **Always Trust**.
+- **Windows:** open it, select **Install Certificate**, and place it in **Trusted Root Certification Authorities**.
+- **Android:** open Security settings, choose **Install a certificate**, and install it as a CA certificate.
 
-1. Download only `mycert.crt`.
-2. Install `mycert.crt` as a trusted root on each client that should use MITM.
-3. Run the health check and confirm it passes.
-4. Continue to PassWall2 routing below if you need selective routing.
+Menu names can vary by operating-system version. Firefox may use a separate certificate store. Some native applications ignore user-installed certificates or use certificate pinning; test a browser first.
 
-If you choose **Advanced settings** instead, the equivalent manual sequence
-is: install the packaged default configuration, generate or import a matching
-certificate and private key as a candidate, activate the candidate, start the
-service, run the health check, and enable automatic startup. Never copy
-`mycert.key` to a client.
+### 3. Configure recommended routing
 
-Trust the downloaded public CA for your current user:
+If you do not need PassWall2 routing, skip this step. Otherwise open **Basic → Routing** and choose:
 
-**MAC:**
+- **Main routing profile** — the shunt profile already active in PassWall2.
+- **Working VPN connection** — an existing VPN node that already works.
 
-```sh
-security add-trusted-cert -r trustRoot \
-  -k "$HOME/Library/Keychains/login.keychain-db" ./mycert.crt
-```
+Select **Review selected routing**, inspect the destinations, and then select **Apply recommended routing**. MITM-compatible routes require the service to be running; start it in **Advanced → Service** if necessary. The assistant validates the preview and preserves unrelated PassWall2 rules.
 
-**WINDOWS PC (PowerShell):**
+### 4. Check that it works
 
-```powershell
-certutil.exe -user -addstore -f Root .\mycert.crt
-```
+Open **Basic → Status** and select **Run check**. This verifies the router-side MITM service. It does not prove that every client trusts `mycert.crt`.
 
-Firefox may use its own certificate store. If it does, import `mycert.crt` inside Firefox too. Never copy `mycert.key` to a client.
+After it passes, test the intended websites from a client browser. A site using MITM should show `MITM-DomainFronting` as its certificate issuer; a VPN-routed or direct site should show its normal public certificate authority.
 
-### 3. Route selected domains through PassWall2
+## Recommended routing
 
-Skip this step if you only need the local SOCKS service.
+The default model is based on traffic purpose:
 
-1. Open the PassWall2 section on the project’s LuCI page.
-2. Choose the existing shunt node and VPN node.
-3. If you select any MITM-compatible service, confirm that the MITM service
-   is running. The assistant will not allow a preview that would send traffic
-   to a stopped local SOCKS listener.
-4. Select **Review selected routing** or **Preview changes**.
-5. Review the local node, domains, destinations, and rule order.
-6. Select **Apply preview** only after the preview is correct.
+| Traffic | Destination | Purpose |
+| --- | --- | --- |
+| Google services | MITM | Use the local MITM service for the selected Google bundle. |
+| Gemini app and API | Selected VPN | Send Gemini traffic through the working VPN. |
+| Iranian websites and IP addresses | Direct | Avoid the VPN and MITM for selected local traffic. |
 
-The assistant creates at most three package-managed rules, in this order:
+Optional service groups are available in **Basic → Routing**:
 
-1. **VPN Overrides** sends selected Gemini, Android connectivity, YouTube control, and Google Account bundles to the chosen VPN. YouTube video delivery (`googlevideo.com`) is deliberately excluded.
-2. **MITM-Compatible Services** sends selected Google, Meta website, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`. Google is recommended; Meta and Fastly stay off until you test them on your devices.
-3. **Regional Direct Access** sends Iranian domains and IP ranges directly.
+- **VPN Overrides** can include Android connectivity checks, YouTube sign-in and controls, and Google Account sign-in. `googlevideo.com` is excluded so high-speed YouTube video delivery can use MITM.
+- **MITM-Compatible Services** can include Google, Meta, and Fastly-backed website groups. Google is the recommended starting point; test Meta and Fastly before relying on native applications.
+- **Regional Direct Access** uses the packaged Iranian domain and IP groups.
 
-The checkboxes add domain bundles to these three rules; they do not create one rule per checkbox. Applying the first three-rule preview migrates older package-managed rules. Recognized user-created legacy rules remain unchanged, but their assignments are removed from the selected shunt to prevent duplicate matches. Keep `localhost_proxy=0` to prevent the standalone Xray output from looping back into PassWall2.
+Each checkbox enables a service group inside one of these assignments; it does not create a separate rule. Most users can keep the recommended choices unchanged.
 
-### 4. Verify from a client
+## Updating
 
-**MAC:**
+Run the same installation command again. It preserves the configuration, active certificate, service state, and PassWall2 routing. Reload LuCI and review the status cards; do not generate a new certificate or repeat setup unless LuCI asks you to.
 
-```sh
-for url in \
-  https://www.google.com \
-  https://www.youtube.com \
-  https://www.cloudflare.com \
-  https://gemini.google.com
-do
-  printf '\n%s\n' "$url"
-  curl -Iv --max-time 20 "$url" 2>&1 |
-    grep -E 'issuer:|^HTTP/'
-done
-```
+## Common problems
 
-**WINDOWS PC (PowerShell):**
+- **PassWall2 is not detected:** MITM can still run, but automatic routing requires PassWall2. Install and enable it, then reload LuCI.
+- **No VPN or routing profile:** add and test a VPN node or shunt profile in PassWall2, then return to **Basic → Routing**.
+- **MITM routes do not work:** in **Advanced → Service**, confirm that MITM is running and the client trusts `mycert.crt`.
+- **Certificate error:** install only the current `mycert.crt`. Never copy `mycert.key`; review certificate state in **Advanced → Certificates**.
+- **Native app fails:** some apps ignore user-installed CAs, use certificate pinning, or use traffic outside the selected group. Confirm the browser path first.
 
-```powershell
-$urls = @(
-  'https://www.google.com',
-  'https://www.youtube.com',
-  'https://www.cloudflare.com',
-  'https://gemini.google.com'
-)
+## Advanced
 
-foreach ($url in $urls) {
-  Write-Host "`n$url"
-  curl.exe -Iv --max-time 20 $url 2>&1 |
-    Select-String -Pattern 'issuer:', 'HTTP/'
-}
-```
+Most users do not need the technical reference. It covers certificate lifecycle, manual service controls, custom routing, rollback, recovery, local SOCKS details, and CLI commands:
 
-A domain using MITM should show:
+- [Advanced usage](docs/ADVANCED.md)
+- [Security](SECURITY.md)
+- [Signed feed operations](docs/SIGNED_FEED.md)
+- [Release testing](docs/RELEASE_TESTING.md)
+- [Contributing and development workflow](CONTRIBUTING.md)
 
-```text
-issuer: CN=MITM-DomainFronting
-```
+## Remove
 
-A domain using VPN or direct routing should show its normal public certificate authority. All expected requests should return a successful HTTP response.
-
-## Updating later
-
-The easiest update is to run the same one-command installer again. After the feed is configured, you can also update directly:
-
-**ROUTER:**
-
-```sh
-apk update
-apk upgrade xray-mitm luci-app-xray-mitm
-```
-
-This upgrades only these two explicitly selected packages and required dependencies. Do not use an unrestricted `apk upgrade` as a replacement for a planned OpenWrt firmware upgrade.
-
-Updates preserve `/etc/config/xray-mitm`, `/etc/xray-mitm/`, the active CA, service settings, and existing PassWall2 configuration. The installer creates `/root/xray-mitm-before-install-YYYYMMDD-HHMMSS.tar.gz` with mode `0600` before changing feed or package state.
-
-After an update, reload LuCI and review the status cards. Do not generate a
-new CA or run first-time setup again unless the page reports that configuration
-or certificate state is missing or needs attention.
-
-## How authentication works
-
-The first one-command run downloads the installer from GitHub over HTTPS. That installer pins the reviewed feed public-key fingerprint shown above. APK then uses the installed public key to authenticate the feed index and every package. Later updates use the same stored key and signed feed.
-
-Production publishing is separate from ordinary pull-request builds:
-
-- Pull requests run offline validation and development artifacts without the production signing key or secrets.
-- A version tag must match the package version exactly.
-- The signing job runs only behind the protected `signed-feed` GitHub environment.
-- The job proves that the protected private key matches the public key committed in `keys/xray-mitm-feed-v1.pem`.
-- OpenWrt’s SDK creates the native signed `packages.adb` index and signed APKs.
-- The workflow publishes the feed through GitHub Pages and keeps the signed files with the matching GitHub Release.
-
-The production private key is never stored in this repository or included in packages. See [Signed feed operations](docs/SIGNED_FEED.md) for publishing, recovery, and key-rotation procedures.
-
-## Requirements and package behavior
-
-The packages are architecture-independent (`all`) but currently require the official OpenWrt 25.12 APK package ecosystem. Dependencies include `xray-core`, `curl`, `openssl-util`, `uci`, `jsonfilter`, `coreutils-stat`, `v2ray-geoip`, and `v2ray-geosite`; LuCI also requires `luci-base`, `rpcd-mod-ucode`, and `ucode-mod-fs`.
-
-The default installation is intentionally inactive. Installing or updating packages does not generate a CA, enable boot startup, start Xray, alter firewall or DNS state, or apply PassWall2 changes. The three Xray listeners remain on localhost:
-
-| Purpose | Address |
-| --- | --- |
-| Local mixed/SOCKS entry | `127.0.0.1:10808` |
-| HTTP/1.1 TLS decrypt tunnel | `127.0.0.1:11666` |
-| HTTP/2 TLS decrypt tunnel | `127.0.0.1:11777` |
-
-## Manual authenticated installation
-
-Use this only when the router cannot reach GitHub Pages. Download the two APKs, `xray-mitm-feed-v1.pem`, `PUBLIC_KEY_SHA256`, and `SHA256SUMS` from the same signed GitHub Release on a Mac or Windows PC.
-
-**ROUTER:**
-
-```sh
-mkdir -p -m 0700 /tmp/xray-mitm-install
-```
-
-**MAC:**
-
-```sh
-cd "/path/to/downloaded/release-files"
-scp -O xray-mitm-*.apk luci-app-xray-mitm-*.apk \
-  xray-mitm-feed-v1.pem PUBLIC_KEY_SHA256 SHA256SUMS \
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-**WINDOWS PC (PowerShell):**
-
-```powershell
-Set-Location "C:\path\to\downloaded\release-files"
-scp.exe -O .\xray-mitm-*.apk .\luci-app-xray-mitm-*.apk `
-  .\xray-mitm-feed-v1.pem .\PUBLIC_KEY_SHA256 .\SHA256SUMS `
-  root@192.168.1.1:/tmp/xray-mitm-install/
-```
-
-Verify the public-key fingerprint before installing it. Stop if it differs from the fingerprint in this README.
-
-**ROUTER:**
-
-```sh
-cd /tmp/xray-mitm-install
-printf '%s  %s\n' \
-  '3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a' \
-  'xray-mitm-feed-v1.pem' | sha256sum -c -
-awk '$2 ~ /[.]apk$/' SHA256SUMS | sha256sum -c -
-mkdir -p /etc/apk/keys
-cp xray-mitm-feed-v1.pem /etc/apk/keys/xray-mitm-feed-v1.pem
-chmod 0644 /etc/apk/keys/xray-mitm-feed-v1.pem
-apk add ./xray-mitm-*.apk ./luci-app-xray-mitm-*.apk
-```
-
-CI development APKs are intentionally outside this production trust path. Do not present them to new users as signed releases.
-
-## Development and release testing
-
-See [Contributing](CONTRIBUTING.md) for the local branch and pull request workflow,
-and [Changelog](CHANGELOG.md) for user-facing release history.
-
-Run all offline safety, installer, routing, certificate, workflow, and syntax checks:
-
-**MAC:**
-
-```sh
-cd "/path/to/xray-mitm-openwrt"
-sh scripts/validate-release.sh
-```
-
-**WINDOWS PC (PowerShell with WSL):**
-
-```powershell
-wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
-```
-
-See [Release testing](docs/RELEASE_TESTING.md) before publishing a tag.
-
-## Removal
-
-Before removing the packages, stop the service, disable boot startup, and use the LuCI PassWall2 rollback if routing was applied. Then remove the packages:
+If routing was applied, roll it back in LuCI first. Then stop and remove the packages on the router:
 
 **ROUTER:**
 
@@ -288,8 +143,8 @@ Before removing the packages, stop the service, disable boot startup, and use th
 apk del luci-app-xray-mitm xray-mitm
 ```
 
-Remove `mycert.crt` from every client trust store when interception is no longer intended. Treat any remaining router backup and `mycert.key` as secret material.
+Remove `mycert.crt` from client trust stores when interception is no longer intended. Treat remaining backups and `mycert.key` as secret material.
 
 ## Attribution
 
-The domain-fronting configuration is derived from [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23), licensed under GPL-3.0. Xray-core, OpenWrt, LuCI, and PassWall2 remain separate upstream projects. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+The packaged domain-fronting configuration is derived from [patterniha/MITM-DomainFronting v23](https://github.com/patterniha/MITM-DomainFronting/tree/v23), licensed under GPL-3.0. Xray-core, OpenWrt, LuCI, and PassWall2 remain separate upstream projects. See [third-party notices](THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security
+
+This project combines HTTPS interception with optional PassWall2 routing. Read this page before installing it.
+
+## MITM trust boundary
+
+A device that trusts the project CA can have HTTPS traffic decrypted for domains sent through the MITM service. Use the software only on networks and devices you own or are authorized to manage.
+
+- Install only the public certificate, `mycert.crt`, on clients.
+- Keep `mycert.key` on the router and in protected backups.
+- Do not place the private key in Git, release assets, screenshots, support messages, or terminal transcripts.
+- The service listeners are intended to remain on `127.0.0.1`.
+- Remove the public certificate from clients when interception is no longer intended.
+
+Some applications ignore user-installed CAs or use certificate pinning. A successful router health check does not prove that every application or client will accept the certificate.
+
+## Signed package feed
+
+The installer and package feed use separate checks:
+
+```text
+download installer over HTTPS
+→ verify the pinned installer SHA-256
+→ download the feed public key
+→ verify the feed key fingerprint
+→ let APK verify the signed package index and packages
+```
+
+The current public feed key is:
+
+```text
+File: keys/xray-mitm-feed-v1.pem
+SHA-256: 3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a
+```
+
+The installer does not use `--allow-untrusted` and does not run an unrestricted system-wide package upgrade. It targets `xray-mitm` and `luci-app-xray-mitm` and keeps a protected backup before changing feed state.
+
+## Production signing boundary
+
+Pull-request builds are development artifacts. They do not receive the production signing private key. Production feed signing runs only through the protected GitHub environment `signed-feed`.
+
+The publishing workflow checks that the protected private key derives the same public key as the committed `keys/xray-mitm-feed-v1.pem`. The private key is never stored in this repository, package files, workflow artifacts, release assets, router images, or commands.
+
+For key storage, publishing, recovery, and rotation procedures, see [Signed feed operations](docs/SIGNED_FEED.md).
+
+## Reporting a security issue
+
+Do not post private keys, router backups, credentials, or sensitive router configuration in a public issue. Use the repository's private GitHub security reporting channel when available, or contact the maintainer privately with the minimum reproducible information.
+

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,0 +1,115 @@
+# Advanced usage
+
+Most users should follow the main [README](../README.md). This page documents the controls and implementation details that are useful when the Basic dashboard needs more information.
+
+## Dashboard modes
+
+The LuCI page uses one client-side view with two modes:
+
+- **Basic** — setup, certificate download, recommended routing, and status.
+- **Advanced** — **Overview**, **Service**, **Certificates**, and **Routing** pages for manual control.
+
+Switching pages does not reload the LuCI view.
+
+## Service and local listeners
+
+Installing or updating packages does not start the service. The Advanced **Service** page can install the packaged default configuration, start or stop the service, enable or disable automatic startup, and run the MITM health check.
+
+The service is designed to keep its listeners on localhost:
+
+| Purpose | Address |
+| --- | --- |
+| Local mixed/SOCKS entry | `127.0.0.1:10808` |
+| HTTP/1.1 TLS decrypt tunnel | `127.0.0.1:11666` |
+| HTTP/2 TLS decrypt tunnel | `127.0.0.1:11777` |
+
+The local SOCKS listener is for the PassWall2 MITM-compatible route. It should not be exposed to the LAN or Internet.
+
+## Certificate lifecycle
+
+The **Certificates** page can show three certificate states:
+
+- **Current** — the active certificate and matching private key used by the service.
+- **Candidate** — a new certificate pair prepared but not yet active.
+- **Previous** — the prior active pair kept for rollback when available.
+
+The application validates certificate and key matching before activation. A candidate is not the same as the current certificate. Clients must trust the public certificate that matches the current active pair.
+
+Only export the public certificate. The private key must remain root-owned with restrictive permissions on the router and in protected backups.
+
+## PassWall2 routing model
+
+The Routing page uses three package-managed rules. Their user-facing names and destinations are:
+
+1. **VPN Overrides** — sends selected Gemini, Android connectivity, YouTube control, and Google Account bundles to the chosen VPN.
+2. **MITM-Compatible Services** — sends selected Google, Meta, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`.
+3. **Regional Direct Access** — sends selected Iranian domains and IP ranges directly.
+
+The available service groups currently map as follows:
+
+| Group | Entries |
+| --- | --- |
+| Gemini app and API | `gemini.google.com`, `generativelanguage.googleapis.com` |
+| Android internet checks | `connectivitycheck.gstatic.com`, `connectivitycheck.android.com`, `clients3.google.com` |
+| YouTube sign-in and controls | `www.youtube.com`, `youtubei.googleapis.com`, `youtube.googleapis.com`, `accounts.youtube.com` |
+| Google Account sign-in | `accounts.google.com` |
+| Google services | `geosite:google` |
+| Meta websites | `geosite:meta` |
+| Fastly-backed websites | `geosite:fastly`, `geosite:reddit`, `geosite:cnn`, `buzzfeed.com` |
+| Iranian websites and IP addresses | `geosite:ir`, `geoip:ir` |
+
+`googlevideo.com` is deliberately excluded from YouTube control routing so video delivery can remain on the MITM path.
+
+The checkboxes select entries inside these assignments. They do not create one PassWall2 rule per checkbox. The assistant creates or reuses the local SOCKS node when needed, previews the exact change, and applies it only after the reviewed preview is accepted.
+
+The first three-rule apply can migrate older package-managed rules. It preserves unrelated user-created rules while removing their selected-shunt assignments when necessary to avoid duplicate matches. The advanced option `localhost_proxy=0` prevents the local MITM connection from being captured again.
+
+## Preview, apply, rollback, and recovery
+
+The routing assistant requires a compatible PassWall2 installation, a selected shunt, a working VPN node, and a writable configuration. It refuses a MITM-dependent apply while the MITM service is stopped.
+
+The assistant creates a private temporary preview first. Applying is limited to that exact preview, and a rollback copy is kept. If an interrupted transaction is reported, use **Recover previous PassWall2 file** before creating another preview.
+
+Pending PassWall2 changes must be saved or reverted before a new preview can be created.
+
+## CLI reference
+
+These commands run on the router. Most return JSON; certificate export returns the public certificate.
+
+**ROUTER:**
+
+```sh
+xray-mitmctl status-json
+xray-mitmctl setup-status-json
+xray-mitmctl setup-recommended
+xray-mitmctl health-json
+xray-mitmctl service start
+xray-mitmctl service stop
+xray-mitmctl service enable
+xray-mitmctl service disable
+xray-mitmctl config-install-default
+xray-mitmctl cert-status-json
+xray-mitmctl cert-export current
+xray-mitmctl passwall2 inspect
+xray-mitmctl passwall2 recover
+```
+
+Certificate generation, import, activation, discard, and rollback require the exact fingerprint arguments shown by the certificate status and are safer through the Advanced page.
+
+## Manual authenticated package installation
+
+Use this only when the router cannot reach GitHub Pages. Download both APKs and the matching `xray-mitm-feed-v1.pem`, `PUBLIC_KEY_SHA256`, and `SHA256SUMS` from one signed GitHub Release. Verify the public-key fingerprint and package checksums before installing.
+
+The current feed-key SHA-256 is documented in [Security](../SECURITY.md). Never use `--allow-untrusted` and never mix APKs from different releases.
+
+## Removal
+
+If PassWall2 routing was applied, roll it back first. On the router, stop and disable the service before removing both packages:
+
+**ROUTER:**
+
+```sh
+/etc/init.d/xray-mitm stop
+/etc/init.d/xray-mitm disable
+apk del luci-app-xray-mitm xray-mitm
+```


### PR DESCRIPTION
## What changed

Refreshes the project documentation for v0.4.2.

- Rewrites the English README as a concise beginner-first guide.
- Updates the Persian README with the same section order and instructions.
- Adds advanced usage documentation for manual controls and CLI commands.
- Adds a security reference for MITM certificates, private keys, and signed feeds.
- Documents the current install, update, certificate, routing, and troubleshooting flow.

No router configuration, service behavior, certificate material, or PassWall2 runtime behavior changed.

## Validation

- [x] `sh scripts/validate-release.sh` passed locally.
- [x] `git diff --check` passed.
- [x] Signed-feed tests passed.
- [x] `CHANGELOG.md` includes an entry under `Unreleased`.
- [x] No private keys, credentials, router backups, or generated packages are included.