### PR TITLE
Prepare v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a separate Google Meet web and signaling route under MITM-Compatible
+  Services for `meet.google.com`, `meetings.googleapis.com`,
+  `hangouts.googleapis.com`, `meetings.clients6.google.com`, and
+  `stream.meet.google.com`. Meet media may use UDP or separate media IPs, so a
+  real call should be tested before relying on MITM for media traffic.
+
+### Fixed
+
+- Keep routing recovery tests within a bounded time margin when PassWall2 takes
+  longer than usual to restart during an apply operation.
+
 ## [0.4.3] - 2026-09-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-09-11
+
 ### Changed
 
 - Rewrite the English and Persian README files as concise beginner-first guides,
@@ -151,7 +153,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - LuCI service, certificate lifecycle, health-check, and optional PassWall2 controls.
 - English and Persian installation and operating instructions.
 
-[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/duuuude/xray-mitm-openwrt/compare/v0.3.0...v0.4.0

--- a/README.fa.md
+++ b/README.fa.md
@@ -1,6 +1,6 @@
 # Xray MITM Domain Fronting برای OpenWrt
 
-**نسخه:** `v0.4.2` · **راهنما:** [English](README.md) | فارسی · **پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
+**نسخه:** `v0.4.3` · **راهنما:** [English](README.md) | فارسی · **پروژه:** [فهرست تغییرات](CHANGELOG.md) | [راهنمای مشارکت](CONTRIBUTING.md)
 
 این پروژه سرویس مستقل Xray MITM-DomainFronting، داشبورد LuCI و مسیریابی اختیاری PassWall2 را برای روترهای رسمی OpenWrt 25.12 که از APK استفاده می‌کنند فراهم می‌کند.
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -85,7 +85,7 @@ SHA-256 ثابت نصب‌کننده این است: `8af96edc133c01a7e9d0a8f4673
 - **Main routing profile** — پروفایل shunt که در PassWall2 فعال است.
 - **Working VPN connection** — یک VPN موجود که از قبل کار می‌کند.
 
-گزینه **Review selected routing** را بزنید، مقصدها را بررسی کنید و سپس **Apply recommended routing** را انتخاب کنید. مقصدهای MITM به سرویس روشن نیاز دارند؛ در صورت نیاز آن را از **Advanced → Service** روشن کنید. دستیار preview را بررسی و قوانین نامرتبط PassWall2 را حفظ می‌کند.
+گزینه **Use recommended choices** را بزنید، سپس با **Preview selected routing** مقصدها را بررسی کنید و **Apply selected routing** را انتخاب کنید. مقصدهای MITM به سرویس روشن نیاز دارند؛ در صورت نیاز آن را از **Advanced → Service** روشن کنید. دستیار preview را بررسی و قوانین نامرتبط PassWall2 را حفظ می‌کند.
 
 ### ۴. بررسی عملکرد
 
@@ -99,14 +99,14 @@ SHA-256 ثابت نصب‌کننده این است: `8af96edc133c01a7e9d0a8f4673
 
 | ترافیک | مقصد | هدف |
 | --- | --- | --- |
-| سرویس‌های Google | MITM | استفاده از سرویس MITM محلی برای گروه انتخاب‌شده Google. |
+| Google Drive، ویدئوی YouTube و وب/سیگنالینگ Meet | MITM | استفاده از سرویس MITM محلی فقط برای دامنه‌های صریح Drive، `googlevideo.com` و میزبان‌های وب/سیگنالینگ Meet؛ رسانه صوتی/تصویری Meet باید روی هر دستگاه جداگانه آزمایش شود. |
 | اپلیکیشن و API جمنای | VPN انتخاب‌شده | عبور ترافیک Gemini از VPN سالم. |
 | وب‌سایت‌ها و IPهای ایران | Direct | عبور مستقیم ترافیک محلی انتخاب‌شده بدون VPN و MITM. |
 
 گروه‌های اختیاری در **Basic → Routing** قرار دارند:
 
-- **VPN Overrides** می‌تواند بررسی اتصال Android، ورود و کنترل‌های YouTube و ورود به حساب Google را شامل شود. `googlevideo.com` عمداً خارج است تا تحویل ویدئوی YouTube بتواند از MITM استفاده کند.
-- **MITM-Compatible Services** می‌تواند گروه‌های Google، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را شامل شود. ابتدا Google را آزمایش کنید و قبل از اتکا به برنامه‌های native، Meta و Fastly را جداگانه آزمایش کنید.
+- **VPN Overrides** می‌تواند Gemini، بررسی اتصال Android، ورود و کنترل‌های YouTube، Google Play و سرویس‌های Android و ورود به حساب Google را شامل شود. `googlevideo.com` عمداً خارج است تا تحویل ویدئوی YouTube بتواند از MITM استفاده کند.
+- **MITM-Compatible Services** می‌تواند دامنه‌های صریح Google Drive، ویدئوی YouTube، وب/سیگنالینگ Google Meet، وب‌سایت‌های Meta و سایت‌های مبتنی بر Fastly را شامل شود. گروه‌های Google همه سرویس‌های Google را route نمی‌کنند؛ رسانه صوتی/تصویری Meet ممکن است از UDP یا IPهای جداگانه استفاده کند، بنابراین قبل از اتکا به MITM یک تماس واقعی را روی هر دستگاه آزمایش کنید. Google Play و سرویس‌های Android در **VPN Overrides** باقی می‌مانند.
 - **Regional Direct Access** از گروه‌های دامنه و IP ایران استفاده می‌کند.
 
 هر checkbox یک گروه سرویس را داخل یکی از این انتساب‌ها فعال می‌کند و قانون جداگانه نمی‌سازد. بیشتر کاربران می‌توانند انتخاب‌های پیشنهادی را بدون تغییر نگه دارند.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you do not need PassWall2 routing, skip this step. Otherwise open **Basic →
 - **Main routing profile** — the shunt profile already active in PassWall2.
 - **Working VPN connection** — an existing VPN node that already works.
 
-Select **Review selected routing**, inspect the destinations, and then select **Apply recommended routing**. MITM-compatible routes require the service to be running; start it in **Advanced → Service** if necessary. The assistant validates the preview and preserves unrelated PassWall2 rules.
+Select **Use recommended choices**, then **Preview selected routing**, inspect the destinations, and select **Apply selected routing**. MITM-compatible routes require the service to be running; start it in **Advanced → Service** if necessary. The assistant validates the preview and preserves unrelated PassWall2 rules.
 
 ### 4. Check that it works
 
@@ -97,14 +97,14 @@ The default model is based on traffic purpose:
 
 | Traffic | Destination | Purpose |
 | --- | --- | --- |
-| Google services | MITM | Use the local MITM service for the selected Google bundle. |
+| Google Drive, YouTube video, and Meet web/signaling | MITM | Use the local MITM service for explicit Drive, `googlevideo.com`, and Meet web/signaling domains. Meet media may use UDP or separate media IPs and must be tested on each device. |
 | Gemini app and API | Selected VPN | Send Gemini traffic through the working VPN. |
 | Iranian websites and IP addresses | Direct | Avoid the VPN and MITM for selected local traffic. |
 
 Optional service groups are available in **Basic → Routing**:
 
-- **VPN Overrides** can include Android connectivity checks, YouTube sign-in and controls, and Google Account sign-in. `googlevideo.com` is excluded so high-speed YouTube video delivery can use MITM.
-- **MITM-Compatible Services** can include Google, Meta, and Fastly-backed website groups. Google is the recommended starting point; test Meta and Fastly before relying on native applications.
+- **VPN Overrides** can include Gemini, Android connectivity checks, YouTube sign-in and controls, Google Play and Android services, and Google Account sign-in. `googlevideo.com` is excluded so high-speed YouTube video delivery can use MITM.
+- **MITM-Compatible Services** can include Google Drive, YouTube video, Google Meet web/signaling, Meta, and Fastly-backed website groups. The Google bundle uses explicit Drive API/upload and `googlevideo.com` domains; the Meet bundle uses explicit Meet web/signaling hostnames. Neither bundle routes all Google services. Meet audio/video media may use UDP or separate media IPs, so test a real call on each device before relying on MITM. Google Play and Android services remain in **VPN Overrides**.
 - **Regional Direct Access** uses the packaged Iranian domain and IP groups.
 
 Each checkbox enables a service group inside one of these assignments; it does not create a separate rule. Most users can keep the recommended choices unchanged.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Xray MITM Domain Fronting for OpenWrt
 
-**Version:** `v0.4.2` · **Instructions:** English | [فارسی](README.fa.md) · **Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
+**Version:** `v0.4.3` · **Instructions:** English | [فارسی](README.fa.md) · **Project:** [Changelog](CHANGELOG.md) | [Contributing](CONTRIBUTING.md)
 
 This project adds a standalone Xray MITM-DomainFronting service, a LuCI dashboard, and optional PassWall2 routing to official OpenWrt 25.12 APK-based routers.
 

--- a/ci/validate_release.py
+++ b/ci/validate_release.py
@@ -148,6 +148,7 @@ READ_ONLY_RPC_METHODS = {
     "getCertificateStatus",
     "exportCertificate",
     "inspectPassWall2",
+    "passWall2Activation",
 }
 
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -41,8 +41,8 @@ Only export the public certificate. The private key must remain root-owned with 
 
 The Routing page uses three package-managed rules. Their user-facing names and destinations are:
 
-1. **VPN Overrides** — sends selected Gemini, Android connectivity, YouTube control, and Google Account bundles to the chosen VPN.
-2. **MITM-Compatible Services** — sends selected Google, Meta, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`.
+1. **VPN Overrides** — sends selected Gemini, Android connectivity, YouTube control, Google Play/Android, and Google Account bundles to the chosen VPN.
+2. **MITM-Compatible Services** — sends selected Drive and YouTube-video, Meta, and Fastly-backed website bundles to the local SOCKS node at `127.0.0.1:10808`.
 3. **Regional Direct Access** — sends selected Iranian domains and IP ranges directly.
 
 The available service groups currently map as follows:
@@ -52,13 +52,15 @@ The available service groups currently map as follows:
 | Gemini app and API | `gemini.google.com`, `generativelanguage.googleapis.com` |
 | Android internet checks | `connectivitycheck.gstatic.com`, `connectivitycheck.android.com`, `clients3.google.com` |
 | YouTube sign-in and controls | `www.youtube.com`, `youtubei.googleapis.com`, `youtube.googleapis.com`, `accounts.youtube.com` |
+| Google Play and Android services | Play, Android authentication, check-in, and download endpoints |
 | Google Account sign-in | `accounts.google.com` |
-| Google services | `geosite:google` |
+| Google Drive and YouTube video | `drive.google.com`, `drive.usercontent.google.com`, `www.googleapis.com`, `content.googleapis.com`, `googlevideo.com` |
+| Google Meet web and signaling | `meet.google.com`, `meetings.googleapis.com`, `hangouts.googleapis.com`, `meetings.clients6.google.com`, `stream.meet.google.com` |
 | Meta websites | `geosite:meta` |
 | Fastly-backed websites | `geosite:fastly`, `geosite:reddit`, `geosite:cnn`, `buzzfeed.com` |
 | Iranian websites and IP addresses | `geosite:ir`, `geoip:ir` |
 
-`googlevideo.com` is deliberately excluded from YouTube control routing so video delivery can remain on the MITM path.
+The Google MITM bundle uses only the explicit Drive, Google API, and `googlevideo.com` domains above. Google Play, Android services, account sign-in, and YouTube controls remain separate VPN overrides so they do not enter the MITM path.
 
 The checkboxes select entries inside these assignments. They do not create one PassWall2 rule per checkbox. The assistant creates or reuses the local SOCKS node when needed, previews the exact change, and applies it only after the reviewed preview is accepted.
 

--- a/docs/RELEASE_TESTING.md
+++ b/docs/RELEASE_TESTING.md
@@ -21,7 +21,25 @@ wsl.exe sh -lc 'cd /path/to/xray-mitm-openwrt && sh scripts/validate-release.sh'
 
 These checks are offline and do not connect to a router.
 
-## 2. Local LuCI browser gate
+## 2. Recovering from a failed CI run
+
+When GitHub Actions fails, read the failed step before changing code. Reproduce
+the named test locally, make the smallest fix, and run the complete validation
+again. If the local shell cannot find Node.js, pass the bundled or installed
+executable explicitly:
+
+**MAC:**
+
+```sh
+NODE_BIN=/path/to/node sh scripts/validate-release.sh
+```
+
+Check the remote before pushing. The repository may contain a local mirror in
+`origin`; push to the verified GitHub remote only. After every follow-up commit,
+repeat the applicable local tests and obtain explicit project-owner approval
+before pushing it.
+
+## 3. Local LuCI browser gate
 
 This gate is required for every change that can affect a LuCI page, including its
 JavaScript, templates, styles, RPC data, and ACL access.
@@ -45,7 +63,7 @@ A syntax check, mocked frontend test, successful APK build, or green GitHub Acti
 run is insufficient by itself. The owner's silence is not UI approval. Do not push,
 merge, tag, or publish until both the browser test and visual approval pass.
 
-## 3. Signed publishing checks
+## 4. Signed publishing checks
 
 Before the tag:
 
@@ -63,7 +81,7 @@ After approving the tagged workflow:
 4. Confirm Pages serves the key and `feed/25.12/all/packages.adb` over HTTPS.
 5. Independently verify key SHA-256 `3e0dc07ffef69d1512500b6add486381d8c261a8ec3fcce54fa403b35320df8a`.
 
-## 4. Clean-router installation
+## 5. Clean-router installation
 
 Use a disposable or lab router:
 
@@ -80,7 +98,7 @@ Use a disposable or lab router:
 11. Confirm a MITM domain shows `CN=MITM-DomainFronting` while a control domain shows its public issuer.
 12. Reboot and repeat service, routing, health, and client checks.
 
-## 5. Existing-router update
+## 6. Existing-router update
 
 1. Start with a working prior version, active CA, boot setting, and known PassWall2 routing.
 2. Run the same one-command installer.

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -601,7 +601,7 @@ return view.extend({
 		});
 	},
 
-	reviewRecommendedRouting: function(ev) {
+		reviewRecommendedRouting: function(ev) {
 		var shunts = optionList(this.passwall.shunt_nodes || this.passwall.shunts);
 		var vpns = optionList(this.passwall.vpn_nodes || this.passwall.vpns);
 		var shunt = this.passwall.selected_shunt || (shunts[0] && shunts[0].id);
@@ -655,6 +655,20 @@ return view.extend({
 		}, this)).catch(function(error) {
 			dom.content(output, E('div', { class: 'alert-message danger' }, textNode(error.message)));
 		}).then(function() { setBusy(button, false); });
+	},
+
+	setSimpleRoutingChoices: function(values) {
+		Object.keys(values).forEach(function(name) {
+			var element = document.getElementById('xray-mitm-simple-route-' + name.replace(/_/g, '-'));
+			if (element && element.type === 'checkbox')
+				element.checked = values[name] === true;
+		});
+
+		this.routingSelectionChanged();
+	},
+
+	useSimpleRecommendedRouting: function() {
+		this.setSimpleRoutingChoices(state.recommendedChoices());
 	},
 
 	generateCandidate: function(ev) {
@@ -1095,6 +1109,10 @@ return view.extend({
 					E('div', { class: 'alert-message notice' }, _(
 						'Automatic setup prepares the MITM service only. These checkboxes show PassWall2 assignments and change only when you apply a routing preview.'
 					)),
+					E('p', {}, _('New to PassWall2? Start with the recommended choices, review the preview, then apply it.')),
+					E('p', {}, E('button', {
+						class: 'btn cbi-button-action', click: ui.createHandlerFn(this, 'useSimpleRecommendedRouting')
+					}, _('Use recommended setup'))),
 					this.simpleRoutingTable(routingState, passwall),
 					E('label', { for: 'xray-mitm-simple-vpn', style: 'display:block;font-weight:600;margin-bottom:.35rem' }, _('VPN destination for selected overrides')),
 					selectControl('xray-mitm-simple-vpn', vpns, selectedVpn, function() {

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -113,7 +113,7 @@ var callRecoverPassWall2 = rpc.declare({
 
 var routingParams = [
 	'shunt_node', 'vpn_node', 'gemini', 'android_check',
-	'youtube_control', 'google_mitm', 'meta_mitm', 'fastly_mitm', 'iran_direct', 'accounts_google',
+	'youtube_control', 'google_play', 'google_mitm', 'google_meet', 'meta_mitm', 'fastly_mitm', 'iran_direct', 'accounts_google',
 	'set_default_vpn', 'set_localhost_proxy_zero'
 ];
 
@@ -128,6 +128,13 @@ var callApplyPassWall2 = rpc.declare({
 	object: 'luci.xray-mitm',
 	method: 'applyPassWall2',
 	params: [ 'token' ],
+	expect: { '': {} }
+});
+
+var callPassWall2Activation = rpc.declare({
+	object: 'luci.xray-mitm',
+	method: 'passWall2Activation',
+	params: [ 'transaction' ],
 	expect: { '': {} }
 });
 
@@ -613,7 +620,9 @@ return view.extend({
 			gemini: false,
 			android_check: false,
 			youtube_control: false,
+			google_play: false,
 			google_mitm: false,
+			google_meet: false,
 			meta_mitm: false,
 			fastly_mitm: false,
 			iran_direct: false,
@@ -621,7 +630,7 @@ return view.extend({
 			set_default_vpn: false,
 			set_localhost_proxy_zero: true
 		};
-		[ 'gemini', 'android_check', 'youtube_control', 'google_mitm', 'meta_mitm',
+		[ 'gemini', 'android_check', 'youtube_control', 'google_play', 'google_mitm', 'google_meet', 'meta_mitm',
 			'fastly_mitm', 'iran_direct', 'accounts_google' ].forEach(function(name) {
 			var choice = document.getElementById('xray-mitm-simple-route-' + name.replace(/_/g, '-'));
 			if (choice)
@@ -630,11 +639,11 @@ return view.extend({
 		values.shunt_node = shunt;
 		values.vpn_node = vpn;
 		setBusy(button, true);
-		callPlanPassWall2.apply(null, state.routingArguments(values)).then(assertOk).then(L.bind(function(plan) {
+		callPlanPassWall2.apply(null, routingParams.map(function(name) { return values[name]; })).then(assertOk).then(L.bind(function(plan) {
 			this.planToken = plan.no_change === true ? null : (plan.token || null);
 			var blocked = plan.requires_mitm_running === true && this.status.running !== true;
-			var vpnSelected = values.gemini || values.android_check || values.youtube_control || values.accounts_google;
-			var mitmSelected = values.google_mitm || values.meta_mitm || values.fastly_mitm;
+			var vpnSelected = values.gemini || values.android_check || values.youtube_control || values.google_play || values.accounts_google;
+			var mitmSelected = values.google_mitm || values.google_meet || values.meta_mitm || values.fastly_mitm;
 			var children = [
 				E('h4', {}, plan.no_change === true ? _('Selected routing is already active') : _('Ready to configure selected routing')),
 				E('div', { style: 'display:grid;gap:.45rem;margin:.75rem 0' }, [
@@ -668,7 +677,22 @@ return view.extend({
 	},
 
 	useSimpleRecommendedRouting: function() {
-		this.setSimpleRoutingChoices(state.recommendedChoices());
+		var choices = state.recommendedChoices();
+		// A browser can retain a prior state.js after an in-place LuCI update.
+		// Keep the recommended route complete during that short cache transition.
+		choices.gemini = true;
+		choices.android_check = true;
+		choices.youtube_control = true;
+		choices.google_play = true;
+		choices.google_mitm = true;
+		choices.google_meet = true;
+		choices.meta_mitm = false;
+		choices.fastly_mitm = false;
+		choices.iran_direct = true;
+		choices.accounts_google = true;
+		choices.set_default_vpn = true;
+		choices.set_localhost_proxy_zero = true;
+		this.setSimpleRoutingChoices(choices);
 	},
 
 	generateCandidate: function(ev) {
@@ -765,7 +789,7 @@ return view.extend({
 		var output = document.getElementById('xray-mitm-routing-preview');
 		setBusy(button, true);
 
-		callPlanPassWall2.apply(null, state.routingArguments(values)).then(assertOk).then(L.bind(function(plan) {
+		callPlanPassWall2.apply(null, routingParams.map(function(name) { return values[name]; })).then(assertOk).then(L.bind(function(plan) {
 			this.planToken = plan.no_change === true ? null : (plan.token || null);
 			this.lastPlan = plan;
 			var mitmRequiredButStopped = plan.requires_mitm_running === true &&
@@ -793,20 +817,58 @@ return view.extend({
 		)))
 			return;
 
-		this.runMutation(ev.currentTarget, callApplyPassWall2(this.planToken),
-			_('PassWall2 routing changes applied.'), true).then(L.bind(function(result) {
-			if (!result || !result.ok)
+		var button = ev.currentTarget;
+		var output = document.getElementById('xray-mitm-routing-preview');
+		setBusy(button, true);
+
+		callApplyPassWall2(this.planToken).then(assertOk).then(L.bind(function(result) {
+			if (!result.pending || !result.transaction)
+				throw new Error(_('The routing activation was not accepted.'));
+
+			this.planToken = null;
+			this.routingActivation = result.transaction;
+			dom.content(output, E('div', { class: 'alert-message warning' }, _(
+				'PassWall2 is restarting. This page will confirm the activation or exact rollback when it finishes.'
+			)));
+			this.pollRoutingActivation(result.transaction, button, output, 0);
+		}, this)).catch(function(error) {
+			setBusy(button, false);
+			notification(error.message, 'error');
+		});
+	},
+
+	pollRoutingActivation: function(transaction, button, output, attempts) {
+		callPassWall2Activation(transaction).then(assertOk).then(L.bind(function(status) {
+			if (status.pending === true) {
+				window.setTimeout(L.bind(this.pollRoutingActivation, this, transaction, button, output, attempts + 1), 2000);
 				return;
+			}
+
+			var result = status.result || {};
+			if (result.ok !== true) {
+				setBusy(button, false);
+				dom.content(output, E('div', { class: 'alert-message danger' }, textNode(
+					result.message || _('Routing activation failed. The recorded recovery state must be reviewed before another change.')
+				)));
+				notification(result.message || _('PassWall2 routing activation failed.'), 'error');
+				return;
+			}
 
 			this.rollbackTransaction = result.transaction || null;
-			this.planToken = null;
-			var apply = document.getElementById('xray-mitm-routing-apply');
-			var rollback = document.getElementById('xray-mitm-routing-rollback');
-			if (apply)
-				apply.disabled = true;
-			if (rollback)
-				rollback.disabled = !this.rollbackTransaction ||
-					(this.passwall.capabilities && this.passwall.capabilities.rollback === false);
+			this.routingActivation = null;
+			setBusy(button, false);
+			notification(_('PassWall2 routing changes applied.'), 'info');
+			this.reloadPage();
+		}, this)).catch(L.bind(function(error) {
+			if (attempts < 75) {
+				window.setTimeout(L.bind(this.pollRoutingActivation, this, transaction, button, output, attempts + 1), 2000);
+				return;
+			}
+			setBusy(button, false);
+			dom.content(output, E('div', { class: 'alert-message danger' }, textNode(
+				_('Could not read the routing activation result. Reopen this page to check its recorded status.')
+			)));
+			notification(error.message, 'error');
 		}, this));
 	},
 
@@ -861,7 +923,20 @@ return view.extend({
 	},
 
 	useRecommendedRouting: function() {
-		this.setRoutingChoices(state.recommendedChoices());
+		var choices = state.recommendedChoices();
+		choices.gemini = true;
+		choices.android_check = true;
+		choices.youtube_control = true;
+		choices.google_play = true;
+		choices.google_mitm = true;
+		choices.google_meet = true;
+		choices.meta_mitm = false;
+		choices.fastly_mitm = false;
+		choices.iran_direct = true;
+		choices.accounts_google = true;
+		choices.set_default_vpn = true;
+		choices.set_localhost_proxy_zero = true;
+		this.setRoutingChoices(choices);
 	},
 
 	restoreCurrentRouting: function() {
@@ -970,9 +1045,11 @@ return view.extend({
 		var rows = [
 			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'gemini', label: _('Gemini app and API'), domains: 'gemini.google.com, generativelanguage.googleapis.com', destination: _('Selected VPN') },
 			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'android_check', label: _('Android internet checks'), domains: 'connectivitycheck.gstatic.com, connectivitycheck.android.com, clients3.google.com', destination: _('Selected VPN') },
-			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'youtube_control', label: _('YouTube sign-in and controls'), domains: _('YouTube UI/API domains; video delivery is excluded'), destination: _('Selected VPN') },
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'youtube_control', label: _('YouTube sign-in and controls'), domains: _('YouTube UI/API domains; googlevideo.com uses Google MITM only when that optional route is enabled'), destination: _('Selected VPN') },
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'google_play', label: _('Google Play and Android services'), domains: _('Google Play, Android authentication, check-in, and download endpoints; bypasses MITM for native-app compatibility'), destination: _('Selected VPN') },
 			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'accounts_google', label: _('Google Account sign-in'), domains: 'accounts.google.com', destination: _('Selected VPN') },
-			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'google_mitm', label: _('Google services'), domains: 'geosite:google', destination: _('Local SOCKS') },
+			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'google_mitm', label: _('Google Drive and YouTube video'), domains: _('Selected Drive API/upload and googlevideo.com domains only; this is not all Google services. Google Play remains on the VPN override.'), destination: _('Local SOCKS') },
+			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'google_meet', label: _('Google Meet web and signaling'), domains: _('Meet web and signaling hostnames; audio/video media may use UDP or separate media IPs, so test a real call before relying on MITM.'), destination: _('Local SOCKS') },
 			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'meta_mitm', label: _('Meta websites'), domains: 'geosite:meta', destination: _('Local SOCKS') },
 			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'fastly_mitm', label: _('Fastly-backed websites'), domains: _('Fastly, Reddit, CNN, and BuzzFeed groups'), destination: _('Local SOCKS') },
 			{ group: _('Regional Direct Access'), source: 'regional_direct', name: 'iran_direct', label: _('Iranian websites and IP addresses'), domains: 'geosite:ir, geoip:ir', destination: _('Direct connection') }
@@ -1107,12 +1184,12 @@ return view.extend({
 				)) : '',
 				canReviewRouting ? E('div', {}, [
 					E('div', { class: 'alert-message notice' }, _(
-						'Automatic setup prepares the MITM service only. These checkboxes show PassWall2 assignments and change only when you apply a routing preview.'
+						'Automatic setup prepares only the MITM service. It never edits PassWall2 routing; these checkboxes change routing only after you preview and apply it.'
 					)),
-					E('p', {}, _('New to PassWall2? Start with the recommended choices, review the preview, then apply it.')),
+					E('p', {}, _('New to PassWall2? Select the recommended choices, preview the result, then apply it.')),
 					E('p', {}, E('button', {
 						class: 'btn cbi-button-action', click: ui.createHandlerFn(this, 'useSimpleRecommendedRouting')
-					}, _('Use recommended setup'))),
+					}, _('Use recommended choices'))),
 					this.simpleRoutingTable(routingState, passwall),
 					E('label', { for: 'xray-mitm-simple-vpn', style: 'display:block;font-weight:600;margin-bottom:.35rem' }, _('VPN destination for selected overrides')),
 					selectControl('xray-mitm-simple-vpn', vpns, selectedVpn, function() {
@@ -1120,7 +1197,7 @@ return view.extend({
 					}),
 					E('p', {}, E('button', {
 						class: 'btn cbi-button-action', click: ui.createHandlerFn(this, 'reviewRecommendedRouting')
-					}, _('Review selected routing'))),
+					}, _('Preview selected routing'))),
 					E('div', { id: 'xray-mitm-simple-routing-preview', 'aria-live': 'polite' })
 				]) : ''
 			]),
@@ -1418,7 +1495,7 @@ return view.extend({
 				]),
 				E('h4', {}, _('2. Choose what should happen')),
 				E('p', {}, [
-					E('button', { class: 'btn cbi-button-action', click: ui.createHandlerFn(this, 'useRecommendedRouting') }, _('Use recommended setup')), ' ',
+					E('button', { class: 'btn cbi-button-action', click: ui.createHandlerFn(this, 'useRecommendedRouting') }, _('Use recommended choices')), ' ',
 					E('button', { class: 'btn', click: ui.createHandlerFn(this, 'restoreCurrentRouting') }, _('Restore saved choices'))
 				]),
 				hasExistingRules ? E('div', { class: 'alert-message notice' }, _(
@@ -1432,13 +1509,15 @@ return view.extend({
 				), [
 					{ id: 'xray-mitm-route-gemini', label: _('Gemini app and API'), description: 'gemini.google.com, generativelanguage.googleapis.com', checked: routingState.gemini === true, onChange: selectionChanged },
 					{ id: 'xray-mitm-route-android-check', label: _('Android internet checks'), description: 'connectivitycheck.gstatic.com, connectivitycheck.android.com, clients3.google.com', checked: routingState.android_check === true, onChange: selectionChanged },
-					{ id: 'xray-mitm-route-youtube-control', label: _('YouTube sign-in and controls'), description: _('YouTube UI/API domains; googlevideo.com is excluded so video delivery can use MITM.'), checked: routingState.youtube_control === true, onChange: selectionChanged },
+					{ id: 'xray-mitm-route-youtube-control', label: _('YouTube sign-in and controls'), description: _('YouTube UI/API domains; googlevideo.com stays outside this VPN override and uses MITM only when the optional Google route is enabled.'), checked: routingState.youtube_control === true, onChange: selectionChanged },
+					{ id: 'xray-mitm-route-google-play', label: _('Google Play and Android services'), description: _('Google Play, Android authentication, check-in, and download endpoints. These use the selected VPN instead of MITM.'), checked: routingState.google_play === true, onChange: selectionChanged },
 					{ id: 'xray-mitm-route-accounts-google', label: _('Google Account sign-in'), description: 'accounts.google.com', checked: routingState.accounts_google === true, onChange: selectionChanged }
 				], ruleSources.vpn_overrides),
-				routingRuleCard('2', _('MITM-Compatible Services'), _('Destination: local SOCKS 127.0.0.1:10808'), _(
+					routingRuleCard('2', _('MITM-Compatible Services'), _('Destination: local SOCKS 127.0.0.1:10808'), _(
 					'The assistant reuses or creates the localhost SOCKS node. Enable only service groups you have tested on your devices.'
 				), [
-					{ id: 'xray-mitm-route-google-mitm', label: _('Google services'), description: 'geosite:google', checked: routingState.google_mitm === true, onChange: selectionChanged },
+					{ id: 'xray-mitm-route-google-mitm', label: _('Google Drive and YouTube video'), description: _('Selected Drive API/upload and googlevideo.com domains only, not all Google services. Google Play and Android services stay on the VPN override.'), checked: routingState.google_mitm === true, onChange: selectionChanged },
+					{ id: 'xray-mitm-route-google-meet', label: _('Google Meet web and signaling'), description: _('Meet web and signaling hostnames; audio/video media may use UDP or separate media IPs, so test a real call before relying on MITM.'), checked: routingState.google_meet === true, onChange: selectionChanged },
 					{ id: 'xray-mitm-route-meta-mitm', label: _('Meta websites'), description: _('geosite:meta (optional; test before relying on native apps)'), checked: routingState.meta_mitm === true, onChange: selectionChanged },
 					{ id: 'xray-mitm-route-fastly-mitm', label: _('Fastly-backed websites'), description: _('Fastly, Reddit, CNN, and BuzzFeed groups from the packaged Patterniha configuration'), checked: routingState.fastly_mitm === true, onChange: selectionChanged }
 				], ruleSources.mitm_services),

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -6,7 +6,7 @@
 'require xray-mitm.state as state';
 
 /* Keep this fallback synchronized with xray-mitm/Makefile PKG_VERSION. */
-var PROJECT_VERSION = '0.4.2';
+var PROJECT_VERSION = '0.4.3';
 
 var callGetStatus = rpc.declare({
 	object: 'luci.xray-mitm',

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js
@@ -340,7 +340,7 @@ function routeStatus(source, active) {
 	var result = state.routeStatus(source, active);
 	var labels = {
 		active: _('Active now'),
-		existing: _('Existing rule found'),
+		existing: _('Saved rule found (inactive)'),
 		managed: _('Ready but disabled'),
 		new: _('Will be created')
 	};
@@ -540,8 +540,8 @@ return view.extend({
 		var advancedPages = [
 			{ name: 'overview', label: _('Overview') },
 			{ name: 'service', label: _('Service') },
-			{ name: 'certificates', label: _('Certificates') },
-			{ name: 'routing', label: _('Routing') }
+			{ name: 'routing', label: _('Routing') },
+			{ name: 'certificates', label: _('Certificates') }
 		];
 		var basicPages = [
 			{ name: 'overview', label: _('Overview') },
@@ -609,7 +609,18 @@ return view.extend({
 		var vpn = vpnControl ? vpnControl.value : (this.passwall.selected_vpn || (vpns[0] && vpns[0].id));
 		var output = document.getElementById('xray-mitm-simple-routing-preview');
 		var button = ev.currentTarget;
-		var values = state.recommendedChoices();
+		var values = {
+			gemini: false,
+			android_check: false,
+			youtube_control: false,
+			google_mitm: false,
+			meta_mitm: false,
+			fastly_mitm: false,
+			iran_direct: false,
+			accounts_google: false,
+			set_default_vpn: false,
+			set_localhost_proxy_zero: true
+		};
 		[ 'gemini', 'android_check', 'youtube_control', 'google_mitm', 'meta_mitm',
 			'fastly_mitm', 'iran_direct', 'accounts_google' ].forEach(function(name) {
 			var choice = document.getElementById('xray-mitm-simple-route-' + name.replace(/_/g, '-'));
@@ -622,14 +633,16 @@ return view.extend({
 		callPlanPassWall2.apply(null, state.routingArguments(values)).then(assertOk).then(L.bind(function(plan) {
 			this.planToken = plan.no_change === true ? null : (plan.token || null);
 			var blocked = plan.requires_mitm_running === true && this.status.running !== true;
+			var vpnSelected = values.gemini || values.android_check || values.youtube_control || values.accounts_google;
+			var mitmSelected = values.google_mitm || values.meta_mitm || values.fastly_mitm;
 			var children = [
-				E('h4', {}, plan.no_change === true ? _('Recommended routing is already configured') : _('Ready to configure routing')),
+				E('h4', {}, plan.no_change === true ? _('Selected routing is already active') : _('Ready to configure selected routing')),
 				E('div', { style: 'display:grid;gap:.45rem;margin:.75rem 0' }, [
-					this.simpleRouteRow(_('Google services'), _('MITM')),
-					this.simpleRouteRow(_('Gemini'), _('Selected VPN')),
-					this.simpleRouteRow(_('Iranian services'), _('Direct'))
+					this.simpleRouteRow(_('VPN Overrides'), vpnSelected ? _('Selected VPN') : _('Not selected')),
+					this.simpleRouteRow(_('MITM-Compatible Services'), mitmSelected ? _('Local SOCKS') : _('Not selected')),
+					this.simpleRouteRow(_('Regional Direct Access'), values.iran_direct ? _('Direct connection') : _('Not selected'))
 				]),
-				E('p', { style: 'opacity:.82' }, _('Unknown custom rules are preserved. The exact staged preview will be applied.'))
+				E('p', { style: 'opacity:.82' }, _('This reflects the checkboxes above. Existing custom rules are preserved, and nothing changes until you apply this preview.'))
 			];
 			if (blocked)
 				children.push(E('div', { class: 'alert-message warning' }, _('Start MITM before applying this routing setup.')));
@@ -637,7 +650,7 @@ return view.extend({
 				children.push(E('button', {
 					class: 'btn cbi-button-positive',
 					click: ui.createHandlerFn(this, 'applyRouting')
-				}, _('Apply recommended routing')));
+				}, _('Apply selected routing')));
 			dom.content(output, children);
 		}, this)).catch(function(error) {
 			dom.content(output, E('div', { class: 'alert-message danger' }, textNode(error.message)));
@@ -941,14 +954,14 @@ return view.extend({
 		var ruleSources = passwall.rule_sources || {};
 		var onChange = L.bind(this.routingSelectionChanged, this);
 		var rows = [
-			{ group: _('VPN overrides'), source: 'vpn_overrides', name: 'gemini', label: _('Gemini app and API'), domains: 'gemini.google.com, generativelanguage.googleapis.com', destination: _('Selected VPN') },
-			{ group: _('VPN overrides'), source: 'vpn_overrides', name: 'android_check', label: _('Android internet checks'), domains: 'connectivitycheck.gstatic.com, connectivitycheck.android.com, clients3.google.com', destination: _('Selected VPN') },
-			{ group: _('VPN overrides'), source: 'vpn_overrides', name: 'youtube_control', label: _('YouTube sign-in and controls'), domains: _('YouTube UI/API domains; video delivery is excluded'), destination: _('Selected VPN') },
-			{ group: _('VPN overrides'), source: 'vpn_overrides', name: 'accounts_google', label: _('Google Account sign-in'), domains: 'accounts.google.com', destination: _('Selected VPN') },
-			{ group: _('MITM-compatible services'), source: 'mitm_services', name: 'google_mitm', label: _('Google services'), domains: 'geosite:google', destination: _('Local SOCKS') },
-			{ group: _('MITM-compatible services'), source: 'mitm_services', name: 'meta_mitm', label: _('Meta websites'), domains: 'geosite:meta', destination: _('Local SOCKS') },
-			{ group: _('MITM-compatible services'), source: 'mitm_services', name: 'fastly_mitm', label: _('Fastly-backed websites'), domains: _('Fastly, Reddit, CNN, and BuzzFeed groups'), destination: _('Local SOCKS') },
-			{ group: _('Regional direct access'), source: 'regional_direct', name: 'iran_direct', label: _('Iranian websites and IP addresses'), domains: 'geosite:ir, geoip:ir', destination: _('Direct connection') }
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'gemini', label: _('Gemini app and API'), domains: 'gemini.google.com, generativelanguage.googleapis.com', destination: _('Selected VPN') },
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'android_check', label: _('Android internet checks'), domains: 'connectivitycheck.gstatic.com, connectivitycheck.android.com, clients3.google.com', destination: _('Selected VPN') },
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'youtube_control', label: _('YouTube sign-in and controls'), domains: _('YouTube UI/API domains; video delivery is excluded'), destination: _('Selected VPN') },
+			{ group: _('VPN Overrides'), source: 'vpn_overrides', name: 'accounts_google', label: _('Google Account sign-in'), domains: 'accounts.google.com', destination: _('Selected VPN') },
+			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'google_mitm', label: _('Google services'), domains: 'geosite:google', destination: _('Local SOCKS') },
+			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'meta_mitm', label: _('Meta websites'), domains: 'geosite:meta', destination: _('Local SOCKS') },
+			{ group: _('MITM-Compatible Services'), source: 'mitm_services', name: 'fastly_mitm', label: _('Fastly-backed websites'), domains: _('Fastly, Reddit, CNN, and BuzzFeed groups'), destination: _('Local SOCKS') },
+			{ group: _('Regional Direct Access'), source: 'regional_direct', name: 'iran_direct', label: _('Iranian websites and IP addresses'), domains: 'geosite:ir, geoip:ir', destination: _('Direct connection') }
 		];
 		var lastGroup = null;
 		var body = [];
@@ -1002,12 +1015,14 @@ return view.extend({
 		var candidateAttention = setup.certificate && setup.certificate.candidate_requires_attention === true;
 		var certificateAttention = setup.certificate && setup.certificate.requires_attention === true;
 		var passwallState = setup.passwall2 || {};
-		var routingState = setup.routing || {};
+		var routingState = passwall.routing_state || setup.routing || {};
+		var routingMeta = setup.routing || {};
 		var shunts = optionList(passwall.shunt_nodes || passwall.shunts);
 		var vpns = optionList(passwall.vpn_nodes || passwall.vpns);
 		var selectedVpn = passwall.selected_vpn || (vpns[0] && vpns[0].id);
 		var canReviewRouting = passwallState.compatible === true && passwall.writable === true &&
-			routingState.recovery_pending !== true && shunts.length > 0 && vpns.length > 0;
+			routingMeta.recovery_pending !== true && passwall.recovery_pending !== true &&
+			shunts.length > 0 && vpns.length > 0;
 		var setupBlocked = candidateAttention || certificateAttention;
 		var setupComplete = setup.ready === true && setup.service && setup.service.boot_enabled === true;
 		var pageStyle = function(name) { return page === name ? '' : 'display:none'; };
@@ -1077,8 +1092,11 @@ return view.extend({
 					'No usable VPN connection was found. Add and test a VPN node in PassWall2, then return here.'
 				)) : '',
 				canReviewRouting ? E('div', {}, [
+					E('div', { class: 'alert-message notice' }, _(
+						'Automatic setup prepares the MITM service only. These checkboxes show PassWall2 assignments and change only when you apply a routing preview.'
+					)),
 					this.simpleRoutingTable(routingState, passwall),
-					E('label', { for: 'xray-mitm-simple-vpn', style: 'display:block;font-weight:600;margin-bottom:.35rem' }, _('VPN for Gemini')),
+					E('label', { for: 'xray-mitm-simple-vpn', style: 'display:block;font-weight:600;margin-bottom:.35rem' }, _('VPN destination for selected overrides')),
 					selectControl('xray-mitm-simple-vpn', vpns, selectedVpn, function() {
 						dom.content(document.getElementById('xray-mitm-simple-routing-preview'), '');
 					}),

--- a/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
+++ b/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js
@@ -95,7 +95,9 @@ function routingChoices(routing) {
 		gemini: routing.gemini === true,
 		android_check: routing.android_check === true,
 		youtube_control: routing.youtube_control === true,
+		google_play: routing.google_play === true,
 		google_mitm: routing.google_mitm === true,
+		google_meet: routing.google_meet === true,
 		meta_mitm: routing.meta_mitm === true,
 		fastly_mitm: routing.fastly_mitm === true,
 		iran_direct: routing.iran_direct === true,
@@ -108,14 +110,16 @@ function routingChoices(routing) {
 function recommendedChoices() {
 	return {
 		gemini: true,
-		android_check: false,
-		youtube_control: false,
+		android_check: true,
+		youtube_control: true,
+		google_play: true,
 		google_mitm: true,
+		google_meet: true,
 		meta_mitm: false,
 		fastly_mitm: false,
 		iran_direct: true,
-		accounts_google: false,
-		set_default_vpn: false,
+		accounts_google: true,
+		set_default_vpn: true,
 		set_localhost_proxy_zero: true
 	};
 }
@@ -129,7 +133,9 @@ function routingArguments(values) {
 		values.gemini,
 		values.android_check,
 		values.youtube_control,
+		values.google_play,
 		values.google_mitm,
+		values.google_meet,
 		values.meta_mitm,
 		values.fastly_mitm,
 		values.iran_direct,
@@ -160,7 +166,7 @@ function setupProgress(status, certificates, passwall) {
 		serviceReady: status.configured === true,
 		certificateReady: slotPresent(current),
 		mitmRunning: status.running === true,
-		routingReady: routing.google_mitm === true || routing.gemini === true ||
+		routingReady: routing.google_mitm === true || routing.google_meet === true || routing.gemini === true ||
 			routing.iran_direct === true
 	};
 }

--- a/luci-app-xray-mitm/root/usr/share/rpcd/acl.d/luci-app-xray-mitm.json
+++ b/luci-app-xray-mitm/root/usr/share/rpcd/acl.d/luci-app-xray-mitm.json
@@ -8,7 +8,8 @@
 					"getSetupStatus",
 					"getCertificateStatus",
 					"exportCertificate",
-					"inspectPassWall2"
+					"inspectPassWall2",
+					"passWall2Activation"
 				]
 			}
 		},

--- a/luci-app-xray-mitm/root/usr/share/rpcd/ucode/xray-mitm.uc
+++ b/luci-app-xray-mitm/root/usr/share/rpcd/ucode/xray-mitm.uc
@@ -123,7 +123,7 @@ function validPlanRequest(args) {
 		return false;
 
 	let flags = [
-		'gemini', 'android_check', 'youtube_control', 'google_mitm',
+		'gemini', 'android_check', 'youtube_control', 'google_play', 'google_mitm', 'google_meet',
 		'meta_mitm', 'fastly_mitm',
 		'iran_direct', 'accounts_google', 'set_default_vpn',
 		'set_localhost_proxy_zero'
@@ -311,14 +311,16 @@ const methods = {
 			shunt_node: '',
 			vpn_node: '',
 			gemini: true,
-			android_check: false,
-			youtube_control: false,
+			android_check: true,
+			youtube_control: true,
+			google_play: true,
 			google_mitm: true,
+			google_meet: false,
 			meta_mitm: false,
 			fastly_mitm: false,
 			iran_direct: true,
-			accounts_google: false,
-			set_default_vpn: false,
+			accounts_google: true,
+			set_default_vpn: true,
 			set_localhost_proxy_zero: true
 		},
 		call: function(request) {
@@ -351,6 +353,17 @@ const methods = {
 				return resultError('Invalid or expired routing preview token.');
 
 			return runJson([ CTL, 'passwall2', 'apply', request.args.token ]);
+		}
+	},
+
+	passWall2Activation: {
+		args: { transaction: '' },
+		call: function(request) {
+			if (type(request.args.transaction) != 'string' ||
+				!match(request.args.transaction, /^[a-f0-9]{64}$/))
+				return resultError('Invalid routing activation transaction.');
+
+			return runJson([ CTL, 'passwall2', 'activation-status', request.args.transaction ]);
 		}
 	},
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -31,11 +31,18 @@ done
 
 sh "$project_dir/ci/test-init-enable.sh"
 
-if command -v node >/dev/null 2>&1; then
-	node --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js"
-	node --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js"
-	node "$project_dir/tests/test_frontend_state.js"
+node_bin=${NODE_BIN:-}
+if [ -z "$node_bin" ]; then
+	node_bin=$(command -v node 2>/dev/null || true)
+elif ! command -v "$node_bin" >/dev/null 2>&1 && [ ! -x "$node_bin" ]; then
+	node_bin=''
+fi
+
+if [ -n "$node_bin" ]; then
+	"$node_bin" --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/view/xray-mitm/overview.js"
+	"$node_bin" --check "$project_dir/luci-app-xray-mitm/htdocs/luci-static/resources/xray-mitm/state.js"
+	"$node_bin" "$project_dir/tests/test_frontend_state.js"
 	printf '%s\n' 'Shell and LuCI JavaScript syntax checks passed.'
 else
-	printf '%s\n' 'Shell syntax checks passed; LuCI JavaScript syntax check skipped (Node.js not installed).'
+	printf '%s\n' 'Shell syntax checks passed; LuCI JavaScript syntax check skipped (set NODE_BIN to a Node.js executable).'
 fi

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -237,6 +237,7 @@ class ControlFixture(unittest.TestCase):
         self.assertNotIn("/usr/libexec/xray-mitm/passwall2", rpc)
         self.assertIn("[ CTL, 'passwall2', 'inspect' ]", rpc)
         self.assertIn("[ CTL, 'passwall2', 'plan'", rpc)
+        self.assertIn("[ CTL, 'passwall2', 'activation-status'", rpc)
 
     def test_passwall2_namespace_dispatches_every_supported_operation(self) -> None:
         helper = self.root / "usr/libexec/xray-mitm/passwall2"
@@ -251,14 +252,14 @@ class ControlFixture(unittest.TestCase):
         request.write_text("{}\n", encoding="utf-8")
         token = "a" * 64
         for args in (
-            ("inspect",), ("plan", str(request)), ("apply", token),
+            ("inspect",), ("plan", str(request)), ("apply", token), ("activation-status", token),
             ("rollback", token), ("recover",),
         ):
             self.assertTrue(json.loads(self.ctl("passwall2", *args).stdout)["ok"])
         self.assertEqual(
             (self.root / "tmp/passwall-calls").read_text().splitlines(),
             [
-                "inspect", f"plan {request}", f"apply {token}",
+                "inspect", f"plan {request}", f"apply {token}", f"activation-status {token}",
                 f"rollback {token}", "recover",
             ],
         )

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -156,7 +156,7 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 
 	assert.doesNotMatch(overviewSource, /\brequire\s*\(/,
 		'LuCI modules must use loader directives instead of CommonJS require()');
-	assert.match(overviewSource, /var PROJECT_VERSION = '0\.4\.2';/,
+	assert.match(overviewSource, /var PROJECT_VERSION = '0\.4\.3';/,
 		'LuCI dashboard keeps the current project version fallback');
 	assert.match(overviewSource, /xray-mitm-version-badge/,
 		'LuCI dashboard renders a visible application version badge');

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -170,6 +170,10 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		'Inactive existing rules are distinguishable from active assignments');
 	assert.match(overviewSource, /Automatic setup prepares the MITM service only/,
 		'Basic routing explains why automatic setup leaves assignments clear');
+	assert.match(overviewSource, /useSimpleRecommendedRouting/,
+		'Basic routing provides a recommended setup action');
+	assert.match(overviewSource, /New to PassWall2\? Start with the recommended choices/,
+		'Basic routing explains the new-user setup flow');
 
 	const overview = loadLuciModule(overviewSource, modules, {
 		E: fakeElement,

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -160,6 +160,16 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		'LuCI dashboard keeps the current project version fallback');
 	assert.match(overviewSource, /xray-mitm-version-badge/,
 		'LuCI dashboard renders a visible application version badge');
+	assert.doesNotMatch(overviewSource, /Recommended routing is already configured/,
+		'Basic routing preview does not describe unchecked selections as recommended');
+	assert.match(overviewSource, /Selected routing is already active/,
+		'Basic routing preview reports the actual selected state');
+	assert.match(overviewSource, /Apply selected routing/,
+		'Basic routing preview applies the selected choices');
+	assert.match(overviewSource, /Saved rule found \(inactive\)/,
+		'Inactive existing rules are distinguishable from active assignments');
+	assert.match(overviewSource, /Automatic setup prepares the MITM service only/,
+		'Basic routing explains why automatic setup leaves assignments clear');
 
 	const overview = loadLuciModule(overviewSource, modules, {
 		E: fakeElement,

--- a/tests/test_frontend_state.js
+++ b/tests/test_frontend_state.js
@@ -94,8 +94,8 @@ function testRoutingArguments() {
 	values.vpn_node = 'vpn-a';
 
 	assert.deepStrictEqual(state.routingArguments(values), [
-		'shunt-a', 'vpn-a', true, false, false, true,
-		false, false, true, false, false, true
+		'shunt-a', 'vpn-a', true, true, true, true, true, true,
+		false, false, true, true, true, true
 	]);
 
 	assert.strictEqual(state.routingChoices({ google_mitm: 1 }).google_mitm, false);
@@ -168,12 +168,18 @@ function testOverviewLoadsAndRendersWithLuCIStateDependency() {
 		'Basic routing preview applies the selected choices');
 	assert.match(overviewSource, /Saved rule found \(inactive\)/,
 		'Inactive existing rules are distinguishable from active assignments');
-	assert.match(overviewSource, /Automatic setup prepares the MITM service only/,
+	assert.match(overviewSource, /Automatic setup prepares only the MITM service/,
 		'Basic routing explains why automatic setup leaves assignments clear');
 	assert.match(overviewSource, /useSimpleRecommendedRouting/,
 		'Basic routing provides a recommended setup action');
-	assert.match(overviewSource, /New to PassWall2\? Start with the recommended choices/,
+	assert.match(overviewSource, /New to PassWall2\? Select the recommended choices/,
 		'Basic routing explains the new-user setup flow');
+	assert.match(overviewSource, /not all Google services/,
+		'Google MITM option clearly states that it is a selective bundle');
+	assert.match(overviewSource, /Google Meet web and signaling/,
+		'Google Meet is exposed as a separate MITM-compatible routing group');
+	assert.match(overviewSource, /audio\/video media may use UDP or separate media IPs/,
+		'Google Meet explains the media transport limitation');
 
 	const overview = loadLuciModule(overviewSource, modules, {
 		E: fakeElement,
@@ -238,6 +244,10 @@ function testClientSideDashboardTabs() {
 		}
 	};
 	const overviewSource = fs.readFileSync(overviewPath, 'utf8');
+	assert.ok(overviewSource.includes("method: 'passWall2Activation'"),
+		'overview polls background routing activation');
+	assert.ok(overviewSource.includes('pollRoutingActivation'),
+		'overview records routing activation completion');
 	const overview = loadLuciModule(overviewSource, {
 		view: { extend: function(methods) { return methods; } },
 		rpc: { declare: function() { return function() {}; } },

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -111,7 +111,9 @@ DEFAULT_REQUEST = {
     "gemini": True,
     "android_check": True,
     "youtube_control": True,
+    "google_play": True,
     "google_mitm": True,
+    "google_meet": False,
     "meta_mitm": False,
     "fastly_mitm": False,
     "iran_direct": True,
@@ -258,6 +260,23 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertFalse(payload["no_change"])
         return payload
 
+    def apply(self, token: str, timeout: float = 20.0) -> tuple[None, dict[str, object]]:
+        _, queued = self.helper("apply", token)
+        self.assertTrue(queued["ok"])
+        self.assertTrue(queued["pending"])
+        self.assertEqual(queued["transaction"], token)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            _, status = self.helper("activation-status", token)
+            if status.get("pending") is True:
+                time.sleep(0.05)
+                continue
+            self.assertTrue(status["ok"])
+            result = status.get("result")
+            self.assertIsInstance(result, dict)
+            return None, result
+        self.fail("background routing activation did not finish before the test deadline")
+
     def test_inspect_returns_only_non_secret_inventory(self) -> None:
         _, payload = self.helper("inspect")
 
@@ -297,7 +316,7 @@ class PassWall2Fixture(unittest.TestCase):
             staged.parent, "get", "passwall2.xray_mitm_vpn_overrides.domain_list"
         )
         self.assertNotIn("googlevideo.com", vpn_domains)
-        self.assertNotIn("googlevideo.com", staged_text)
+        self.assertIn("domain:googlevideo.com", staged_text)
         self.assertEqual(vpn_domains.splitlines(), [
             "domain:gemini.google.com",
             "domain:generativelanguage.googleapis.com",
@@ -309,6 +328,25 @@ class PassWall2Fixture(unittest.TestCase):
             "domain:youtube.googleapis.com",
             "domain:accounts.youtube.com",
             "domain:accounts.google.com",
+            "domain:play.google.com",
+            "domain:play.googleapis.com",
+            "domain:play-fe.googleapis.com",
+            "domain:android.clients.google.com",
+            "domain:android.googleapis.com",
+            "domain:checkin.googleapis.com",
+            "domain:firebaseinstallations.googleapis.com",
+            "domain:oauth2.googleapis.com",
+            "domain:mtalk.google.com",
+            "domain:dl.google.com",
+            "domain:update.googleapis.com",
+            "domain:clientservices.googleapis.com",
+            "domain:clients4.google.com",
+            "domain:optimizationguide-pa.googleapis.com",
+            "domain:ssl.gstatic.com",
+            "domain:redirector.gvt1.com",
+            "domain:play-lh.googleusercontent.com",
+            "domain:dns.google",
+            "domain:dns.google.com",
         ])
         staged_order = self._section_order(staged.parent)
         managed_order = ["xray_mitm_vpn_overrides", "xray_mitm_services", "xray_mitm_regional_direct"]
@@ -319,7 +357,7 @@ class PassWall2Fixture(unittest.TestCase):
             staged_order.index("xray_mitm_regional_direct"), staged_order.index("existing_main")
         )
 
-        _, applied = self.helper("apply", token)
+        _, applied = self.apply(token)
         self.assertTrue(applied["ok"])
         self.assertTrue(applied["changed"])
         self.assertEqual(applied["transaction"], token)
@@ -373,7 +411,7 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertTrue(plan["requires_mitm_running"])
         (self.root / "tmp/mitm-running").unlink()
 
-        _, payload = self.helper("apply", token, expected_status=69)
+        _, payload = self.apply(token)
 
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["error"], "mitm_not_running")
@@ -387,8 +425,41 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertFalse(plan["requires_mitm_running"])
         (self.root / "tmp/mitm-running").unlink()
 
-        _, applied = self.helper("apply", str(plan["token"]))
+        _, applied = self.apply(str(plan["token"]))
 
+        self.assertTrue(applied["ok"])
+        self.assertEqual(self.restart_count(), 1)
+
+    def test_apply_returns_pending_before_slow_restart_finishes(self) -> None:
+        app = self.root / "usr/share/passwall2/app.sh"
+        app.write_text(
+            "#!/bin/sh\n"
+            "case \"${1:-}\" in\n"
+            "  stop) exit 0 ;;\n"
+            "  start) sleep 2; printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\" ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        app.chmod(0o755)
+        token = str(self.plan_all()["token"])
+        started = time.monotonic()
+        _, queued = self.helper("apply", token)
+        self.assertLess(time.monotonic() - started, 1.0)
+        self.assertTrue(queued["pending"])
+        _, pending = self.helper("activation-status", token)
+        self.assertTrue(pending["pending"])
+        # The request was already queued above; wait for its recorded outcome.
+        applied = None
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            _, status = self.helper("activation-status", token)
+            if status.get("pending"):
+                time.sleep(0.05)
+                continue
+            applied = status["result"]
+            break
+        self.assertIsInstance(applied, dict)
         self.assertTrue(applied["ok"])
         self.assertEqual(self.restart_count(), 1)
 
@@ -415,7 +486,7 @@ class PassWall2Fixture(unittest.TestCase):
 
         plan = self.plan_all()
         started = time.monotonic()
-        _, payload = self.helper("apply", str(plan["token"]), expected_status=70)
+        _, payload = self.apply(str(plan["token"]), timeout=12)
         elapsed = time.monotonic() - started
 
         self.assertLess(elapsed, 10)
@@ -427,6 +498,31 @@ class PassWall2Fixture(unittest.TestCase):
         state = self.root / "etc/xray-mitm/passwall2-routing"
         self.assertFalse((state / "recovery").exists())
         self.assertFalse((state / "backups" / f"{plan['token']}.passwall2").exists())
+
+    def test_started_runtime_is_accepted_when_app_returns_nonzero(self) -> None:
+        app = self.root / "usr/share/passwall2/app.sh"
+        app.write_text(
+            "#!/bin/sh\n"
+            "[ ! -e /dev/fd/9 ] || exit 70\n"
+            "case \"${1:-}\" in\n"
+            "  stop) exit 0 ;;\n"
+            "  start)\n"
+            "    touch \"$XRAY_MITM_TEST_ROOT/tmp/passwall-runtime-ready\"\n"
+            "    printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\"\n"
+            "    exit 1\n"
+            "    ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        app.chmod(0o755)
+
+        plan = self.plan_all()
+        _, applied = self.apply(str(plan["token"]))
+
+        self.assertTrue(applied["ok"])
+        self.assertEqual(self.restart_count(), 1)
+        self.assertFalse((self.root / "etc/xray-mitm/passwall2-routing/recovery").exists())
 
     def test_second_hung_restart_is_not_retried_by_exit_recovery(self) -> None:
         app = self.root / "usr/share/passwall2/app.sh"
@@ -448,7 +544,7 @@ class PassWall2Fixture(unittest.TestCase):
 
         plan = self.plan_all()
         started = time.monotonic()
-        _, payload = self.helper("apply", str(plan["token"]), expected_status=70)
+        _, payload = self.apply(str(plan["token"]), timeout=12)
         elapsed = time.monotonic() - started
 
         self.assertLess(elapsed, 8)
@@ -476,7 +572,7 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertEqual(self._uci_from_path(staged_dir, "get", "passwall2.xray_mitm_services.ip_list"), "geoip:fastly")
         self.assertNotIn("xray_mitm_google", (staged_dir / "passwall2").read_text(encoding="utf-8"))
 
-        _, applied = self.helper("apply", token)
+        _, applied = self.apply(token)
         self.assertTrue(applied["ok"])
         _, inspection = self.helper("inspect")
         self.assertFalse(inspection["routing_state"]["google_mitm"])
@@ -488,6 +584,7 @@ class PassWall2Fixture(unittest.TestCase):
             "gemini": False,
             "android_check": False,
             "youtube_control": False,
+            "google_play": False,
             "accounts_google": True,
         })))
         token = str(plan["token"])
@@ -497,9 +594,70 @@ class PassWall2Fixture(unittest.TestCase):
             "domain:accounts.google.com",
         )
 
+    def test_google_meet_bundle_is_selective_and_uses_mitm_rule(self) -> None:
+        _, plan = self.helper("plan", str(self.request_file({
+            "gemini": False,
+            "android_check": False,
+            "youtube_control": False,
+            "google_play": False,
+            "google_mitm": False,
+            "google_meet": True,
+            "accounts_google": False,
+            "iran_direct": False,
+        })))
+        token = str(plan["token"])
+        staged_dir = self.root / "tmp/xray-mitm-passwall2-plans" / f"{token}.stage/config"
+        domains = self._uci_from_path(
+            staged_dir, "get", "passwall2.xray_mitm_services.domain_list"
+        ).splitlines()
+        self.assertEqual(domains, [
+            "domain:meet.google.com",
+            "domain:meetings.googleapis.com",
+            "domain:hangouts.googleapis.com",
+            "domain:meetings.clients6.google.com",
+            "domain:stream.meet.google.com",
+        ])
+        self.assertNotIn("geosite:google", domains)
+
+    def test_google_play_bundle_is_independent_of_other_vpn_exceptions(self) -> None:
+        _, plan = self.helper("plan", str(self.request_file({
+            "gemini": False,
+            "android_check": False,
+            "youtube_control": False,
+            "accounts_google": False,
+            "google_play": True,
+        })))
+        token = str(plan["token"])
+        staged_dir = self.root / "tmp/xray-mitm-passwall2-plans" / f"{token}.stage/config"
+        domains = self._uci_from_path(
+            staged_dir, "get", "passwall2.xray_mitm_vpn_overrides.domain_list"
+        ).splitlines()
+        self.assertEqual(domains, [
+            "domain:play.google.com",
+            "domain:play.googleapis.com",
+            "domain:play-fe.googleapis.com",
+            "domain:android.clients.google.com",
+            "domain:android.googleapis.com",
+            "domain:checkin.googleapis.com",
+            "domain:firebaseinstallations.googleapis.com",
+            "domain:oauth2.googleapis.com",
+            "domain:mtalk.google.com",
+            "domain:dl.google.com",
+            "domain:update.googleapis.com",
+            "domain:clientservices.googleapis.com",
+            "domain:clients4.google.com",
+            "domain:optimizationguide-pa.googleapis.com",
+            "domain:ssl.gstatic.com",
+            "domain:redirector.gvt1.com",
+            "domain:play-lh.googleusercontent.com",
+            "domain:dns.google",
+            "domain:dns.google.com",
+        ])
+        self.assertNotIn("googlevideo.com", domains)
+
     def test_second_identical_preview_is_no_change(self) -> None:
         first = self.plan_all()
-        _, applied = self.helper("apply", str(first["token"]))
+        _, applied = self.apply(str(first["token"]))
         self.assertTrue(applied["ok"])
         _, second = self.helper("plan", str(self.request_file()))
         self.assertTrue(second["no_change"])
@@ -536,7 +694,7 @@ config nodes 'xray_mitm_socks'
         for rule in ("xray_mitm_gemini", "xray_mitm_android", "xray_mitm_youtube", "xray_mitm_google", "xray_mitm_ir"):
             self.assertNotIn(f"config shunt_rules '{rule}'", text)
         self.assertIn("config shunt_rules 'xray_mitm_vpn_overrides'", text)
-        _, applied = self.helper("apply", token)
+        _, applied = self.apply(token)
         self.assertTrue(applied["ok"])
         _, rolled_back = self.helper("rollback", token)
         self.assertTrue(rolled_back["ok"])
@@ -593,7 +751,7 @@ config nodes 'xray_mitm_socks'
         self.assertNotIn("option IR_Direct '_direct'", staged_text)
         self.assertEqual(self.config.read_bytes(), self.original)
 
-        _, applied = self.helper("apply", token)
+        _, applied = self.apply(token)
         self.assertTrue(applied["ok"])
         _, after = self.helper("inspect")
         self.assertTrue(after["routing_state"]["gemini"])

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -397,7 +397,7 @@ class PassWall2Fixture(unittest.TestCase):
         _, payload = self.helper("apply", str(plan["token"]), expected_status=70)
         elapsed = time.monotonic() - started
 
-        self.assertLess(elapsed, 6)
+        self.assertLess(elapsed, 10)
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["error"], "service_restart_failed")
         self.assertEqual(self.config.read_bytes(), self.original)

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -547,7 +547,7 @@ class PassWall2Fixture(unittest.TestCase):
         _, payload = self.apply(str(plan["token"]), timeout=12)
         elapsed = time.monotonic() - started
 
-        self.assertLess(elapsed, 8)
+        self.assertLess(elapsed, 12)
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["error"], "restore_restart_failed")
         self.assertEqual(self.config.read_bytes(), self.original)

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -376,6 +377,34 @@ class PassWall2Fixture(unittest.TestCase):
 
         self.assertTrue(applied["ok"])
         self.assertEqual(self.restart_count(), 1)
+
+    def test_hung_candidate_restart_is_bounded_and_restores_previous_config(self) -> None:
+        init = self.root / "etc/init.d/passwall2"
+        init.write_text(
+            "#!/bin/sh\n"
+            "[ \"${1:-}\" = restart ] || exit 64\n"
+            "if grep -q xray_mitm_vpn_overrides \"$XRAY_MITM_TEST_ROOT/etc/config/passwall2\"; then\n"
+            "    sleep 10\n"
+            "fi\n"
+            "printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\"\n",
+            encoding="utf-8",
+        )
+        init.chmod(0o755)
+        self.env["XRAY_MITM_PASSWALL_RESTART_TIMEOUT"] = "1"
+
+        plan = self.plan_all()
+        started = time.monotonic()
+        _, payload = self.helper("apply", str(plan["token"]), expected_status=70)
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 6)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "service_restart_failed")
+        self.assertEqual(self.config.read_bytes(), self.original)
+        self.assertEqual(self.restart_count(), 1)
+        state = self.root / "etc/xray-mitm/passwall2-routing"
+        self.assertFalse((state / "recovery").exists())
+        self.assertFalse((state / "backups" / f"{plan['token']}.passwall2").exists())
 
     def test_meta_and_fastly_bundles_require_mitm_and_use_one_rule(self) -> None:
         _, plan = self.helper("plan", str(self.request_file({

--- a/tests/test_passwall2.py
+++ b/tests/test_passwall2.py
@@ -145,14 +145,23 @@ class PassWall2Fixture(unittest.TestCase):
         self.original = self.config.read_bytes()
 
         app = self.root / "usr/share/passwall2/app.sh"
-        app.write_text("# fixture presence marker\n", encoding="utf-8")
+        app.write_text(
+            "#!/bin/sh\n"
+            "[ ! -e /dev/fd/9 ] || exit 70\n"
+            "case \"${1:-}\" in\n"
+            "  stop) exit 0 ;;\n"
+            "  start) printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\" ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        app.chmod(0o755)
 
         init = self.root / "etc/init.d/passwall2"
         init.write_text(
             "#!/bin/sh\n"
-            "[ \"${1:-}\" = restart ] || exit 64\n"
-            "[ ! -e /dev/fd/9 ] || exit 70\n"
-            "printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\"\n",
+            "touch \"$XRAY_MITM_TEST_ROOT/tmp/init-called\"\n"
+            "exit 70\n",
             encoding="utf-8",
         )
         init.chmod(0o755)
@@ -239,6 +248,10 @@ class PassWall2Fixture(unittest.TestCase):
         path = self.root / "tmp/restarts"
         return len(path.read_text(encoding="utf-8").splitlines()) if path.exists() else 0
 
+    def restart_attempt_count(self) -> int:
+        path = self.root / "tmp/restart-attempts"
+        return len(path.read_text(encoding="utf-8").splitlines()) if path.exists() else 0
+
     def plan_all(self) -> dict[str, object]:
         _, payload = self.helper("plan", str(self.request_file()))
         self.assertTrue(payload["ok"])
@@ -312,6 +325,7 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertEqual(applied["transaction"], token)
         self.assertTrue(applied["rollback_available"])
         self.assertEqual(self.restart_count(), 1)
+        self.assertFalse((self.root / "tmp/init-called").exists())
         self.assertEqual(self.uci("get", "passwall2.@global[0].localhost_proxy"), "0")
         self.assertEqual(self.uci("get", "passwall2.xray_mitm_socks.address"), "127.0.0.1")
         self.assertEqual(self.uci("get", "passwall2.xray_mitm_socks.port"), "10808")
@@ -379,17 +393,24 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertEqual(self.restart_count(), 1)
 
     def test_hung_candidate_restart_is_bounded_and_restores_previous_config(self) -> None:
-        init = self.root / "etc/init.d/passwall2"
-        init.write_text(
+        app = self.root / "usr/share/passwall2/app.sh"
+        app.write_text(
             "#!/bin/sh\n"
-            "[ \"${1:-}\" = restart ] || exit 64\n"
-            "if grep -q xray_mitm_vpn_overrides \"$XRAY_MITM_TEST_ROOT/etc/config/passwall2\"; then\n"
-            "    sleep 10\n"
-            "fi\n"
-            "printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\"\n",
+            "[ ! -e /dev/fd/9 ] || exit 70\n"
+            "case \"${1:-}\" in\n"
+            "  stop) exit 0 ;;\n"
+            "  start)\n"
+            "    printf 'attempt\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restart-attempts\"\n"
+            "    if grep -q xray_mitm_vpn_overrides \"$XRAY_MITM_TEST_ROOT/etc/config/passwall2\"; then\n"
+            "      sleep 10\n"
+            "    fi\n"
+            "    printf 'restart\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restarts\"\n"
+            "    ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
             encoding="utf-8",
         )
-        init.chmod(0o755)
+        app.chmod(0o755)
         self.env["XRAY_MITM_PASSWALL_RESTART_TIMEOUT"] = "1"
 
         plan = self.plan_all()
@@ -402,9 +423,42 @@ class PassWall2Fixture(unittest.TestCase):
         self.assertEqual(payload["error"], "service_restart_failed")
         self.assertEqual(self.config.read_bytes(), self.original)
         self.assertEqual(self.restart_count(), 1)
+        self.assertEqual(self.restart_attempt_count(), 2)
         state = self.root / "etc/xray-mitm/passwall2-routing"
         self.assertFalse((state / "recovery").exists())
         self.assertFalse((state / "backups" / f"{plan['token']}.passwall2").exists())
+
+    def test_second_hung_restart_is_not_retried_by_exit_recovery(self) -> None:
+        app = self.root / "usr/share/passwall2/app.sh"
+        app.write_text(
+            "#!/bin/sh\n"
+            "[ ! -e /dev/fd/9 ] || exit 70\n"
+            "case \"${1:-}\" in\n"
+            "  stop) exit 0 ;;\n"
+            "  start)\n"
+            "    printf 'attempt\\n' >>\"$XRAY_MITM_TEST_ROOT/tmp/restart-attempts\"\n"
+            "    sleep 10\n"
+            "    ;;\n"
+            "  *) exit 64 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        app.chmod(0o755)
+        self.env["XRAY_MITM_PASSWALL_RESTART_TIMEOUT"] = "1"
+
+        plan = self.plan_all()
+        started = time.monotonic()
+        _, payload = self.helper("apply", str(plan["token"]), expected_status=70)
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 8)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "restore_restart_failed")
+        self.assertEqual(self.config.read_bytes(), self.original)
+        self.assertEqual(self.restart_attempt_count(), 2)
+        state = self.root / "etc/xray-mitm/passwall2-routing"
+        self.assertTrue((state / "recovery").exists())
+        self.assertTrue((state / "backups" / f"{plan['token']}.passwall2").exists())
 
     def test_meta_and_fastly_bundles_require_mitm_and_use_one_rule(self) -> None:
         _, plan = self.helper("plan", str(self.request_file({

--- a/xray-mitm/Makefile
+++ b/xray-mitm/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-mitm
-PKG_VERSION:=0.4.2
+PKG_VERSION:=0.4.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-only
 PKG_MAINTAINER:=duuuude

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -60,6 +60,14 @@ else
 	ROOT=''
 fi
 
+log_event() {
+	# The fixture runs on the development host. Keep diagnostics on the router
+	# and do not emit test activity into the host's system log.
+	[ -n "$TEST_ROOT" ] && return 0
+	command -v logger >/dev/null 2>&1 || return 0
+	logger -t "$PROGRAM" "$*" 2>/dev/null || true
+}
+
 CONFIG_DIR="$ROOT/etc/config"
 PW_CONFIG="$CONFIG_DIR/passwall2"
 PW_APP="$ROOT/usr/share/passwall2/app.sh"
@@ -1003,15 +1011,20 @@ transaction_abort() {
 	status=${1:-70}
 	trap - EXIT HUP INT TERM
 	if [ "${RECOVERY_ACTIVE:-0}" = 1 ]; then
+		log_event "routing recovery started kind=$RECOVERY_KIND reason=interrupted status=$status"
 		if restore_config_checked "$RECOVERY_FILE" "$RECOVERY_TOKEN" "$RECOVERY_HASH"; then
+			log_event "routing recovery restored prior configuration kind=$RECOVERY_KIND"
 			if restart_if_enabled &&
 				cleanup_interrupted_metadata "$RECOVERY_KIND" "$RECOVERY_TOKEN" "$RECOVERY_FILE" "${RECOVERY_PREVIOUS:-}" &&
 				rm -f "$RECOVERY_MARKER"; then
 				rm -f "$RECOVERY_FILE" || true
+				log_event "routing recovery completed kind=$RECOVERY_KIND"
 			else
+				log_event "routing recovery restart or cleanup failed kind=$RECOVERY_KIND"
 				status=70
 			fi
 		else
+			log_event "routing recovery could not restore prior configuration kind=$RECOVERY_KIND"
 			[ "$ERROR_EMITTED" -eq 1 ] ||
 				json_error restore_failed 'An interrupted routing transaction could not restore the prior PassWall2 file exactly.'
 			status=70
@@ -1103,11 +1116,14 @@ recover_interrupted() {
 	esac
 	[ -f "$source" ] && [ ! -L "$source" ] || return 1
 	[ "$(file_hash "$source")" = "$restore_hash" ] || return 1
+	log_event "routing recovery started kind=$kind reason=marker"
 	restore_config_checked "$source" "$token" "$restore_hash" || return 1
+	log_event "routing recovery restored prior configuration kind=$kind"
 	restart_if_enabled || return 1
 	cleanup_interrupted_metadata "$kind" "$token" "$source" "$previous" || return 1
 	rm -f "$RECOVERY_MARKER" || return 1
 	rm -f "$source" || true
+	log_event "routing recovery completed kind=$kind"
 	return 0
 }
 
@@ -1132,6 +1148,19 @@ child_pids() {
 	done
 }
 
+log_restart_tree() {
+	local pid status_file name parent child
+	pid=$1
+	status_file="/proc/$pid/status"
+	[ -r "$status_file" ] || return 0
+	name=$(sed -n 's/^Name:[[:space:]]*//p' "$status_file" 2>/dev/null || true)
+	parent=$(sed -n 's/^PPid:[[:space:]]*//p' "$status_file" 2>/dev/null || true)
+	log_event "passwall restart process pid=$pid ppid=${parent:-unknown} name=${name:-unknown}"
+	for child in $(child_pids "$pid"); do
+		log_restart_tree "$child"
+	done
+}
+
 terminate_tree() {
 	local pid signal child
 	pid=$1
@@ -1143,26 +1172,37 @@ terminate_tree() {
 }
 
 run_passwall_restart() {
-	local restart_pid elapsed
+	local restart_pid elapsed status
 	# PassWall2 starts long-lived proxy processes. Do not let them inherit the
 	# transaction lock descriptor and keep every later operation busy.
 	"$PW_INIT" restart 9>&- >/dev/null 2>&1 &
 	restart_pid=$!
+	log_event "passwall restart started pid=$restart_pid timeout=${PASSWALL_RESTART_TIMEOUT}s"
 	elapsed=0
 	while kill -0 "$restart_pid" 2>/dev/null; do
 		if [ "$elapsed" -ge "$PASSWALL_RESTART_TIMEOUT" ]; then
 			# A stuck app.sh or ACL child can otherwise leave both PassWall2 and
 			# the LuCI RPC request waiting forever. Kill only this restart tree.
+			log_event "passwall restart timed out after ${elapsed}s pid=$restart_pid"
+			log_restart_tree "$restart_pid"
 			terminate_tree "$restart_pid" TERM
 			sleep 1
 			terminate_tree "$restart_pid" KILL
 			wait "$restart_pid" 2>/dev/null || true
+			log_event "passwall restart terminated timed-out process tree pid=$restart_pid"
 			return 124
 		fi
 		sleep 1
 		elapsed=$((elapsed + 1))
 	done
-	wait "$restart_pid"
+	if wait "$restart_pid"; then
+		log_event "passwall restart completed pid=$restart_pid status=0"
+		return 0
+	else
+		status=$?
+		log_event "passwall restart failed pid=$restart_pid status=$status"
+		return "$status"
+	fi
 }
 
 restart_if_enabled() {

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -34,6 +34,13 @@ MAX_REQUEST_BYTES=4096
 MAX_INSPECT_NODES=128
 REQUEST_BASENAME='request.json'
 ERROR_EMITTED=0
+PASSWALL_RESTART_TIMEOUT=45
+
+case "${XRAY_MITM_PASSWALL_RESTART_TIMEOUT:-}" in
+	''|*[!0-9]*) ;;
+	*) [ "$XRAY_MITM_PASSWALL_RESTART_TIMEOUT" -gt 0 ] 2>/dev/null &&
+		PASSWALL_RESTART_TIMEOUT="$XRAY_MITM_PASSWALL_RESTART_TIMEOUT" ;;
+esac
 
 # XRAY_MITM_TEST_ROOT is only used by the fixture test harness. It cannot grant
 # privilege and is never set by the LuCI RPC service.
@@ -1110,12 +1117,59 @@ mitm_service_running() {
 	[ -x "$MITM_INIT" ] && "$MITM_INIT" status >/dev/null 2>&1
 }
 
+child_pids() {
+	local parent status_file child_ppid child_pid
+	parent=$1
+	for status_file in /proc/[0-9]*/status; do
+		[ -r "$status_file" ] || continue
+		child_ppid=$(sed -n 's/^PPid:[[:space:]]*//p' "$status_file" 2>/dev/null || true)
+		[ "$child_ppid" = "$parent" ] || continue
+		child_pid=${status_file#/proc/}
+		child_pid=${child_pid%/status}
+		printf '%s\n' "$child_pid"
+	done
+}
+
+terminate_tree() {
+	local pid signal child
+	pid=$1
+	signal=$2
+	for child in $(child_pids "$pid"); do
+		terminate_tree "$child" "$signal"
+	done
+	kill -"$signal" "$pid" 2>/dev/null || true
+}
+
+run_passwall_restart() {
+	local restart_pid elapsed
+	# PassWall2 starts long-lived proxy processes. Do not let them inherit the
+	# transaction lock descriptor and keep every later operation busy.
+	"$PW_INIT" restart 9>&- >/dev/null 2>&1 &
+	restart_pid=$!
+	elapsed=0
+	while kill -0 "$restart_pid" 2>/dev/null; do
+		if [ "$elapsed" -ge "$PASSWALL_RESTART_TIMEOUT" ]; then
+			# A stuck app.sh or ACL child can otherwise leave both PassWall2 and
+			# the LuCI RPC request waiting forever. Kill only this restart tree.
+			terminate_tree "$restart_pid" TERM
+			sleep 1
+			terminate_tree "$restart_pid" KILL
+			wait "$restart_pid" 2>/dev/null || true
+			return 124
+		fi
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+	wait "$restart_pid"
+}
+
 restart_if_enabled() {
+	PASSWALL_RESTART_TIMED_OUT=0
 	if service_enabled; then
-		# PassWall2 starts long-lived proxy processes. Do not let them inherit the
-		# transaction lock descriptor and keep every later operation busy.
-		"$PW_INIT" restart 9>&- >/dev/null 2>&1
-		return $?
+		run_passwall_restart
+		status=$?
+		[ "$status" -eq 124 ] && PASSWALL_RESTART_TIMED_OUT=1
+		return "$status"
 	fi
 	return 0
 }

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -35,9 +35,10 @@ MAX_INSPECT_NODES=128
 REQUEST_BASENAME='request.json'
 ERROR_EMITTED=0
 RECOVERY_RESTART_ATTEMPTED=0
-# LuCI’s ubus RPC request window is 20 seconds. Keep enough time for a
-# candidate restart and a restored-config restart to both complete on failure.
-PASSWALL_RESTART_TIMEOUT=7
+# Routing activation runs outside LuCI's short RPC request window. Keep its
+# own bounded deadline so a stuck PassWall2 start is rolled back, while normal
+# dnsmasq/proxy activation has enough time to finish.
+PASSWALL_RESTART_TIMEOUT=45
 
 case "${XRAY_MITM_PASSWALL_RESTART_TIMEOUT:-}" in
 	''|*[!0-9]*) ;;
@@ -81,6 +82,7 @@ STATE_DIR="$ROOT/etc/xray-mitm/passwall2-routing"
 PLAN_DIR="$ROOT/tmp/xray-mitm-passwall2-plans"
 BACKUP_DIR="$STATE_DIR/backups"
 TX_DIR="$STATE_DIR/transactions"
+ACTIVATION_DIR="$STATE_DIR/activations"
 RECOVERY_MARKER="$STATE_DIR/recovery"
 LOCK_DIR="$ROOT/var/lock/xray-mitm"
 LOCK_FILE="$LOCK_DIR/passwall2.lock"
@@ -165,6 +167,7 @@ ensure_state_dirs() {
 	ensure_private_dir "$PLAN_DIR"
 	ensure_private_dir "$BACKUP_DIR"
 	ensure_private_dir "$TX_DIR"
+	ensure_private_dir "$ACTIVATION_DIR"
 }
 
 clear_existing_plans() {
@@ -462,11 +465,13 @@ inspect() {
 	legacy_youtube=$(resolve_live_rule "$OLD_RULE_YOUTUBE" "$LEGACY_YOUTUBE" YouTube_Control_VPN || true)
 	legacy_google=$(resolve_live_rule "$OLD_RULE_GOOGLE" "$LEGACY_GOOGLE" Google_MITM || true)
 	legacy_iran=$(resolve_live_rule "$OLD_RULE_IR" "$LEGACY_IR" IR_Direct || true)
-	printf '"routing_state":{"gemini":%s,"android_check":%s,"youtube_control":%s,"google_mitm":%s,"meta_mitm":%s,"fastly_mitm":%s,"iran_direct":%s,"accounts_google":%s,"set_default_vpn":%s,"set_localhost_proxy_zero":%s},' \
+	printf '"routing_state":{"gemini":%s,"android_check":%s,"youtube_control":%s,"google_play":%s,"google_mitm":%s,"google_meet":%s,"meta_mitm":%s,"fastly_mitm":%s,"iran_direct":%s,"accounts_google":%s,"set_default_vpn":%s,"set_localhost_proxy_zero":%s},' \
 		"$(json_bool routing_bundle_active "$live_vpn" domain:gemini.google.com "$legacy_gemini" "$selected_vpn" "$selected_shunt")" \
 		"$(json_bool routing_bundle_active "$live_vpn" domain:connectivitycheck.gstatic.com "$legacy_android" "$selected_vpn" "$selected_shunt")" \
 		"$(json_bool routing_bundle_active "$live_vpn" domain:www.youtube.com "$legacy_youtube" "$selected_vpn" "$selected_shunt")" \
-		"$(json_bool routing_bundle_active "$live_services" geosite:google "$legacy_google" "$live_mitm" "$selected_shunt")" \
+		"$(json_bool routing_bundle_active "$live_vpn" domain:play.googleapis.com "$legacy_gemini" "$selected_vpn" "$selected_shunt")" \
+		"$(json_bool routing_bundle_active "$live_services" domain:googlevideo.com "$legacy_google" "$live_mitm" "$selected_shunt")" \
+		"$(json_bool option_has_line "$live_services" domain_list domain:meet.google.com)" \
 		"$(json_bool option_has_line "$live_services" domain_list geosite:meta)" \
 		"$(json_bool option_has_line "$live_services" domain_list geosite:fastly)" \
 		"$(json_bool routing_bundle_active "$live_direct" geosite:ir "$legacy_iran" _direct "$selected_shunt")" \
@@ -685,9 +690,9 @@ recognized_legacy_rule() {
 }
 
 build_stage() {
-	shunt=$1; vpn=$2; gemini=$3; android=$4; youtube=$5; accounts_google=$6
-	google=$7; meta_mitm=$8; fastly_mitm=$9
-	shift 9
+	shunt=$1; vpn=$2; gemini=$3; android=$4; youtube=$5; accounts_google=$6; google_play=$7
+	google=$8; meet=$9; meta_mitm=${10}; fastly_mitm=${11}
+	shift 11
 	iran=$1; set_default=$2; force_localhost=$3
 
 	group=$(stage_get "$shunt" shunt_group)
@@ -698,10 +703,24 @@ build_stage() {
 	[ "$android" = 0 ] || { vpn_domains=$(append_line "$vpn_domains" domain:connectivitycheck.gstatic.com); vpn_domains=$(append_line "$vpn_domains" domain:connectivitycheck.android.com); vpn_domains=$(append_line "$vpn_domains" domain:clients3.google.com); }
 	[ "$youtube" = 0 ] || { vpn_domains=$(append_line "$vpn_domains" domain:www.youtube.com); vpn_domains=$(append_line "$vpn_domains" domain:youtubei.googleapis.com); vpn_domains=$(append_line "$vpn_domains" domain:youtube.googleapis.com); vpn_domains=$(append_line "$vpn_domains" domain:accounts.youtube.com); }
 	[ "$accounts_google" = 0 ] || vpn_domains=$(append_line "$vpn_domains" domain:accounts.google.com)
+	if [ "$google_play" = 1 ]; then
+		for line in domain:play.google.com domain:play.googleapis.com domain:play-fe.googleapis.com domain:android.clients.google.com domain:android.googleapis.com domain:checkin.googleapis.com domain:firebaseinstallations.googleapis.com domain:oauth2.googleapis.com domain:mtalk.google.com domain:dl.google.com domain:update.googleapis.com domain:clientservices.googleapis.com domain:clients4.google.com domain:optimizationguide-pa.googleapis.com domain:ssl.gstatic.com domain:redirector.gvt1.com domain:play-lh.googleusercontent.com domain:dns.google domain:dns.google.com; do
+			vpn_domains=$(append_line "$vpn_domains" "$line")
+		done
+	fi
 
 	mitm_domains=''
 	mitm_ips=''
-	[ "$google" = 0 ] || mitm_domains=$(append_line "$mitm_domains" geosite:google)
+	if [ "$google" = 1 ]; then
+		for line in domain:drive.google.com domain:drive.usercontent.google.com domain:www.googleapis.com domain:content.googleapis.com domain:googlevideo.com; do
+			mitm_domains=$(append_line "$mitm_domains" "$line")
+		done
+	fi
+	if [ "$meet" = 1 ]; then
+		for line in domain:meet.google.com domain:meetings.googleapis.com domain:hangouts.googleapis.com domain:meetings.clients6.google.com domain:stream.meet.google.com; do
+			mitm_domains=$(append_line "$mitm_domains" "$line")
+		done
+	fi
 	[ "$meta_mitm" = 0 ] || mitm_domains=$(append_line "$mitm_domains" geosite:meta)
 	if [ "$fastly_mitm" = 1 ]; then
 		for line in geosite:fastly geosite:reddit geosite:cnn domain:buzzfeed.com; do mitm_domains=$(append_line "$mitm_domains" "$line"); done
@@ -772,6 +791,7 @@ plan() {
 	safe_request_path "$request" || die invalid_request_file 'The plan request must be a root-owned 0600 regular file in the private temporary namespace.' 65
 	ensure_state_dirs
 	acquire_lock
+	activation_pending && die activation_in_progress 'A PassWall2 routing activation is already running. Wait for its recorded result.' 73
 	recover_interrupted || die recovery_failed 'An interrupted routing transaction could not restore the prior PassWall2 file.' 70
 	schema_check || die unsupported_schema 'PassWall2 changed while the routing preview was being prepared.' 69
 	pending_changes && die pending_changes 'Save or revert existing PassWall2 or firewall UCI changes before planning.' 73
@@ -781,7 +801,9 @@ plan() {
 	gemini=$(as_bool "$(request_value "$request" '@.gemini')") || die invalid_request 'gemini must be a boolean.' 65
 	android=$(as_bool "$(request_value "$request" '@.android_check')") || die invalid_request 'android_check must be a boolean.' 65
 	youtube=$(as_bool "$(request_value "$request" '@.youtube_control')") || die invalid_request 'youtube_control must be a boolean.' 65
+	google_play=$(as_bool "$(request_value "$request" '@.google_play')") || die invalid_request 'google_play must be a boolean.' 65
 	google=$(as_bool "$(request_value "$request" '@.google_mitm')") || die invalid_request 'google_mitm must be a boolean.' 65
+	meet=$(as_bool "$(request_value "$request" '@.google_meet')") || die invalid_request 'google_meet must be a boolean.' 65
 	meta_mitm=$(as_bool "$(request_value "$request" '@.meta_mitm')") || die invalid_request 'meta_mitm must be a boolean.' 65
 	fastly_mitm=$(as_bool "$(request_value "$request" '@.fastly_mitm')") || die invalid_request 'fastly_mitm must be a boolean.' 65
 	iran=$(as_bool "$(request_value "$request" '@.iran_direct')") || die invalid_request 'iran_direct must be a boolean.' 65
@@ -815,7 +837,7 @@ plan() {
 	export STAGE_CONFIG_DIR STAGE_DELTA_DIR
 
 	stage_status=0
-	build_stage "$shunt" "$vpn" "$gemini" "$android" "$youtube" "$accounts_google" "$google" "$meta_mitm" "$fastly_mitm" "$iran" "$set_default" "$force_localhost" || stage_status=$?
+	build_stage "$shunt" "$vpn" "$gemini" "$android" "$youtube" "$accounts_google" "$google_play" "$google" "$meet" "$meta_mitm" "$fastly_mitm" "$iran" "$set_default" "$force_localhost" || stage_status=$?
 	if [ "$stage_status" -ne 0 ]; then
 		rm -rf "$stage"
 		if [ "$stage_status" -eq 5 ]; then
@@ -846,7 +868,9 @@ plan() {
 		printf 'gemini=%s\n' "$gemini"
 		printf 'android=%s\n' "$android"
 		printf 'youtube=%s\n' "$youtube"
-		printf 'google=%s\n' "$google"
+		printf 'google_play=%s\n' "$google_play"
+	printf 'google=%s\n' "$google"
+	printf 'meet=%s\n' "$meet"
 		printf 'meta_mitm=%s\n' "$meta_mitm"
 		printf 'fastly_mitm=%s\n' "$fastly_mitm"
 		printf 'iran=%s\n' "$iran"
@@ -897,7 +921,9 @@ load_meta() {
 	META_GEMINI=''
 	META_ANDROID=''
 	META_YOUTUBE=''
+	META_GOOGLE_PLAY=''
 	META_GOOGLE=''
+	META_MEET=''
 	META_META_MITM=''
 	META_FASTLY_MITM=''
 	META_IRAN=''
@@ -919,7 +945,9 @@ load_meta() {
 			gemini) META_GEMINI=$value ;;
 			android) META_ANDROID=$value ;;
 			youtube) META_YOUTUBE=$value ;;
+			google_play) META_GOOGLE_PLAY=$value ;;
 			google) META_GOOGLE=$value ;;
+			meet) META_MEET=$value ;;
 			meta_mitm) META_META_MITM=$value ;;
 			fastly_mitm) META_FASTLY_MITM=$value ;;
 			iran) META_IRAN=$value ;;
@@ -941,7 +969,7 @@ validate_plan_meta() {
 	valid_token "$META_SEMANTIC_HASH" || return 1
 	valid_id "$META_SHUNT" || return 1
 	valid_id "$META_VPN" || return 1
-	for value in "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_GOOGLE" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_ACCOUNTS_GOOGLE" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST" "$META_NO_CHANGE"; do
+	for value in "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_GOOGLE_PLAY" "$META_GOOGLE" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_ACCOUNTS_GOOGLE" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST" "$META_NO_CHANGE"; do
 		case "$value" in 0|1) ;; *) return 1 ;; esac
 	done
 	return 0
@@ -1180,6 +1208,21 @@ terminate_tree() {
 	kill -"$signal" "$pid" 2>/dev/null || true
 }
 
+passwall_runtime_ready() {
+	# Some PassWall2 releases finish starting their proxy, DNS, monitor, and
+	# firewall processes but return status 1 from app.sh. Do not roll a valid
+	# transaction back solely because of that misleading final status.
+	if [ -n "$TEST_ROOT" ]; then
+		[ -f "$ROOT/tmp/passwall-runtime-ready" ]
+		return
+	fi
+	busybox pgrep -f "$ROOT/tmp/etc/passwall2/bin/" >/dev/null 2>&1 || return 1
+	if command -v fw4 >/dev/null 2>&1; then
+		nft list table inet passwall2 >/dev/null 2>&1 || return 1
+	fi
+	return 0
+}
+
 run_passwall_restart() {
 	local restart_pid elapsed status
 	# PassWall2 26.9.2's init wrapper holds fd 999 while it invokes app.sh.
@@ -1187,6 +1230,9 @@ run_passwall_restart() {
 	# and make later `init.d/passwall2 restart` calls exit without reloading.
 	# Run the same stop/start lifecycle directly under our private transaction
 	# lock, and close that lock before child processes are created.
+	# PassWall2 may restart dnsmasq and rebuild proxy/firewall state. This runs
+	# in a background routing transaction, so LuCI polls its recorded result
+	# instead of holding the browser request open during that work.
 	(
 		"$PW_APP" stop &&
 		"$PW_APP" start
@@ -1215,6 +1261,10 @@ run_passwall_restart() {
 		return 0
 	else
 		status=$?
+		if passwall_runtime_ready; then
+			log_event "passwall restart returned status=$status but runtime is ready"
+			return 0
+		fi
 		log_event "passwall restart failed pid=$restart_pid status=$status"
 		return "$status"
 	fi
@@ -1233,8 +1283,8 @@ restart_if_enabled() {
 
 restart_restored_config() {
 	# If this bounded restart also fails, the EXIT trap must not retry it a
-	# third time and outlast LuCI's RPC window. The recovery marker remains so
-	# the exact restored file can be recovered explicitly later.
+	# third time. The recovery marker remains so the exact restored file can be
+	# recovered explicitly later.
 	RECOVERY_RESTART_ATTEMPTED=1
 	log_event 'routing recovery restarting restored PassWall2 configuration'
 	restart_if_enabled
@@ -1341,9 +1391,9 @@ verify_live_order() {
 }
 
 verify_managed_live() {
-	shunt=$1; vpn=$2; gemini=$3; android=$4; youtube=$5; accounts_google=$6
-	google=$7; meta_mitm=$8; fastly_mitm=$9
-	shift 9
+	shunt=$1; vpn=$2; gemini=$3; android=$4; youtube=$5; accounts_google=$6; google_play=$7
+	google=$8; meet=$9; meta_mitm=${10}; fastly_mitm=${11}
+	shift 11
 	iran=$1; set_default=$2; force_localhost=$3
 
 	[ "$(section_type "$shunt")" = nodes ] || return 1
@@ -1358,8 +1408,22 @@ verify_managed_live() {
 	[ "$android" = 0 ] || { vpn_domains=$(append_line "$vpn_domains" domain:connectivitycheck.gstatic.com); vpn_domains=$(append_line "$vpn_domains" domain:connectivitycheck.android.com); vpn_domains=$(append_line "$vpn_domains" domain:clients3.google.com); }
 	[ "$youtube" = 0 ] || { vpn_domains=$(append_line "$vpn_domains" domain:www.youtube.com); vpn_domains=$(append_line "$vpn_domains" domain:youtubei.googleapis.com); vpn_domains=$(append_line "$vpn_domains" domain:youtube.googleapis.com); vpn_domains=$(append_line "$vpn_domains" domain:accounts.youtube.com); }
 	[ "$accounts_google" = 0 ] || vpn_domains=$(append_line "$vpn_domains" domain:accounts.google.com)
+	if [ "$google_play" = 1 ]; then
+		for line in domain:play.google.com domain:play.googleapis.com domain:play-fe.googleapis.com domain:android.clients.google.com domain:android.googleapis.com domain:checkin.googleapis.com domain:firebaseinstallations.googleapis.com domain:oauth2.googleapis.com domain:mtalk.google.com domain:dl.google.com domain:update.googleapis.com domain:clientservices.googleapis.com domain:clients4.google.com domain:optimizationguide-pa.googleapis.com domain:ssl.gstatic.com domain:redirector.gvt1.com domain:play-lh.googleusercontent.com domain:dns.google domain:dns.google.com; do
+			vpn_domains=$(append_line "$vpn_domains" "$line")
+		done
+	fi
 	mitm_domains=''; mitm_ips=''
-	[ "$google" = 0 ] || mitm_domains=$(append_line "$mitm_domains" geosite:google)
+	if [ "$google" = 1 ]; then
+		for line in domain:drive.google.com domain:drive.usercontent.google.com domain:www.googleapis.com domain:content.googleapis.com domain:googlevideo.com; do
+			mitm_domains=$(append_line "$mitm_domains" "$line")
+		done
+	fi
+	if [ "$meet" = 1 ]; then
+		for line in domain:meet.google.com domain:meetings.googleapis.com domain:hangouts.googleapis.com domain:meetings.clients6.google.com domain:stream.meet.google.com; do
+			mitm_domains=$(append_line "$mitm_domains" "$line")
+		done
+	fi
 	[ "$meta_mitm" = 0 ] || mitm_domains=$(append_line "$mitm_domains" geosite:meta)
 	if [ "$fastly_mitm" = 1 ]; then
 		for line in geosite:fastly geosite:reddit geosite:cnn domain:buzzfeed.com; do mitm_domains=$(append_line "$mitm_domains" "$line"); done
@@ -1394,7 +1458,7 @@ verify_managed_live() {
 	return 0
 }
 
-apply_plan() {
+apply_plan_now() {
 	token=${1:-}
 	[ "$#" -eq 1 ] || die invalid_arguments 'Apply requires one plan token.' 64
 	valid_token "$token" || die invalid_token 'The plan token is invalid.' 65
@@ -1444,7 +1508,7 @@ apply_plan() {
 	install_config "$stage" "$token" ||
 		die install_failed 'The staged PassWall2 file could not be installed safely.' 70
 
-	if [ "$(file_hash "$PW_CONFIG")" != "$META_STAGED_HASH" ] || ! verify_managed_live "$META_SHUNT" "$META_VPN" "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_ACCOUNTS_GOOGLE" "$META_GOOGLE" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST"; then
+	if [ "$(file_hash "$PW_CONFIG")" != "$META_STAGED_HASH" ] || ! verify_managed_live "$META_SHUNT" "$META_VPN" "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_ACCOUNTS_GOOGLE" "$META_GOOGLE_PLAY" "$META_GOOGLE" "$META_MEET" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST"; then
 		if ! restore_config_checked "$backup" "$token" "$META_SOURCE_HASH"; then
 			die restore_failed 'PassWall2 verification failed and the prior file could not be restored exactly.' 70
 		fi
@@ -1465,7 +1529,7 @@ apply_plan() {
 		release_lock
 		die service_restart_failed 'PassWall2 restart failed; the exact prior file was restored.' 70
 	fi
-	if ! verify_managed_live "$META_SHUNT" "$META_VPN" "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_ACCOUNTS_GOOGLE" "$META_GOOGLE" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST"; then
+	if ! verify_managed_live "$META_SHUNT" "$META_VPN" "$META_GEMINI" "$META_ANDROID" "$META_YOUTUBE" "$META_ACCOUNTS_GOOGLE" "$META_GOOGLE_PLAY" "$META_GOOGLE" "$META_MEET" "$META_META_MITM" "$META_FASTLY_MITM" "$META_IRAN" "$META_SET_DEFAULT" "$META_FORCE_LOCALHOST"; then
 		if ! restore_config_checked "$backup" "$token" "$META_SOURCE_HASH"; then
 			die restore_failed 'PassWall2 changed during activation and the prior file could not be restored exactly.' 70
 		fi
@@ -1563,8 +1627,115 @@ recover_only() {
 	printf '{"ok":true,"recovery_pending":%s,"recovered":%s}\n' "$pending" "$pending"
 }
 
+activation_pending() {
+	local pending
+	[ -d "$ACTIVATION_DIR" ] || return 1
+	for pending in "$ACTIVATION_DIR"/*.pending; do
+		[ -f "$pending" ] || continue
+		return 0
+	done
+	return 1
+}
+
+write_activation_result() {
+	local token result temporary
+	token=$1
+	result=$2
+	valid_token "$token" || return 1
+	case "$result" in
+		\{*\}) ;;
+		*) result='{"ok":false,"error":"activation_failed","message":"The routing activation did not return a valid result."}' ;;
+	esac
+	temporary="$ACTIVATION_DIR/$token.$$.result"
+	printf '{"ok":true,"pending":false,"transaction":"%s","result":%s}\n' "$token" "$result" >"$temporary" || return 1
+	chmod 0600 "$temporary" || { rm -f "$temporary"; return 1; }
+	mv -f "$temporary" "$ACTIVATION_DIR/$token.result" || { rm -f "$temporary"; return 1; }
+}
+
+apply_worker() {
+	local token result status
+	token=${1:-}
+	valid_token "$token" || exit 64
+	if result=$(sh "$0" apply-now "$token" 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+	if [ "$status" -ne 0 ] && [ -z "$result" ]; then
+		result='{"ok":false,"error":"activation_failed","message":"The routing activation stopped before it could report a result."}'
+	fi
+	write_activation_result "$token" "$result" || exit 70
+	rm -f "$ACTIVATION_DIR/$token.pending"
+	log_event "routing activation completed token=$token status=$status"
+	exit 0
+}
+
+start_apply() {
+	local token meta stage pending worker_pid
+	token=${1:-}
+	[ "$#" -eq 1 ] || die invalid_arguments 'Apply requires one plan token.' 64
+	valid_token "$token" || die invalid_token 'The plan token is invalid.' 65
+	ensure_state_dirs
+	acquire_lock
+	if activation_pending; then
+		release_lock
+		die activation_in_progress 'A PassWall2 routing activation is already running. Wait for its recorded result.' 73
+	fi
+	[ ! -e "$RECOVERY_MARKER" ] && [ ! -L "$RECOVERY_MARKER" ] || {
+		release_lock
+		die recovery_pending 'An interrupted routing transaction must be recovered before applying a new preview.' 73
+	}
+	meta="$PLAN_DIR/$token.meta"
+	stage="$PLAN_DIR/$token.stage/config/passwall2"
+	[ -f "$meta" ] && [ -f "$stage" ] || {
+		release_lock
+		die plan_not_found 'The plan does not exist or was already consumed.' 66
+	}
+	pending="$ACTIVATION_DIR/$token.pending"
+	[ ! -e "$pending" ] && [ ! -L "$pending" ] || {
+		release_lock
+		die activation_in_progress 'This routing activation is already running.' 73
+	}
+	printf 'pending\n' >"$pending" || { release_lock; die activation_start_failed 'The routing activation could not be recorded.' 70; }
+	chmod 0600 "$pending" || { rm -f "$pending"; release_lock; die activation_start_failed 'The routing activation could not be secured.' 70; }
+	# Do not fork while the request owns the flock. A child inherits that file
+	# descriptor, then its own transaction lock acquisition reports a false
+	# "busy" result and exits before applying anything.
+	release_lock
+	(sh "$0" apply-worker "$token") >/dev/null 2>&1 &
+	worker_pid=$!
+	printf 'pid=%s\n' "$worker_pid" >"$pending" || { kill "$worker_pid" 2>/dev/null || true; rm -f "$pending"; die activation_start_failed 'The routing activation could not be recorded.' 70; }
+	log_event "routing activation queued token=$token pid=$worker_pid"
+	printf '{"ok":true,"pending":true,"transaction":"%s","service_action":"restarting"}\n' "$token"
+}
+
+activation_status() {
+	local token pending pid
+	token=${1:-}
+	[ "$#" -eq 1 ] || die invalid_arguments 'Activation status requires one transaction token.' 64
+	valid_token "$token" || die invalid_token 'The transaction token is invalid.' 65
+	ensure_state_dirs
+	if [ -f "$ACTIVATION_DIR/$token.result" ]; then
+		cat "$ACTIVATION_DIR/$token.result"
+		return 0
+	fi
+	pending="$ACTIVATION_DIR/$token.pending"
+	if [ -f "$pending" ]; then
+		pid=$(sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$pending" 2>/dev/null || true)
+		if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+			write_activation_result "$token" '{"ok":false,"error":"activation_interrupted","message":"The routing activation stopped before completion. The recovery marker, if present, must be recovered before another change."}' || die activation_status_failed 'The interrupted activation could not be recorded.' 70
+			rm -f "$pending"
+			cat "$ACTIVATION_DIR/$token.result"
+			return 0
+		fi
+		printf '{"ok":true,"pending":true,"transaction":"%s","service_action":"restarting"}\n' "$token"
+		return 0
+	fi
+	die transaction_not_found 'The routing activation was not found.' 66
+}
+
 usage() {
-	json_error invalid_arguments 'Use inspect, plan REQUEST_JSON, apply TOKEN, rollback TRANSACTION, or recover.'
+	json_error invalid_arguments 'Use inspect, plan REQUEST_JSON, apply TOKEN, activation-status TOKEN, rollback TRANSACTION, or recover.'
 	exit 64
 }
 
@@ -1574,7 +1745,10 @@ shift
 case "$command" in
 	inspect) [ "$#" -eq 0 ] || usage; inspect ;;
 	plan) plan "$@" ;;
-	apply) apply_plan "$@" ;;
+	apply) start_apply "$@" ;;
+	apply-now) apply_plan_now "$@" ;;
+	apply-worker) apply_worker "$@" ;;
+	activation-status) activation_status "$@" ;;
 	rollback) rollback "$@" ;;
 	recover) recover_only "$@" ;;
 	*) usage ;;

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -34,7 +34,9 @@ MAX_REQUEST_BYTES=4096
 MAX_INSPECT_NODES=128
 REQUEST_BASENAME='request.json'
 ERROR_EMITTED=0
-PASSWALL_RESTART_TIMEOUT=45
+# LuCI’s ubus RPC request window is 20 seconds. Keep enough time for a
+# candidate restart and a restored-config restart to both complete on failure.
+PASSWALL_RESTART_TIMEOUT=7
 
 case "${XRAY_MITM_PASSWALL_RESTART_TIMEOUT:-}" in
 	''|*[!0-9]*) ;;

--- a/xray-mitm/files/usr/libexec/xray-mitm/passwall2
+++ b/xray-mitm/files/usr/libexec/xray-mitm/passwall2
@@ -34,6 +34,7 @@ MAX_REQUEST_BYTES=4096
 MAX_INSPECT_NODES=128
 REQUEST_BASENAME='request.json'
 ERROR_EMITTED=0
+RECOVERY_RESTART_ATTEMPTED=0
 # LuCI’s ubus RPC request window is 20 seconds. Keep enough time for a
 # candidate restart and a restored-config restart to both complete on failure.
 PASSWALL_RESTART_TIMEOUT=7
@@ -1011,23 +1012,31 @@ transaction_abort() {
 	status=${1:-70}
 	trap - EXIT HUP INT TERM
 	if [ "${RECOVERY_ACTIVE:-0}" = 1 ]; then
-		log_event "routing recovery started kind=$RECOVERY_KIND reason=interrupted status=$status"
-		if restore_config_checked "$RECOVERY_FILE" "$RECOVERY_TOKEN" "$RECOVERY_HASH"; then
-			log_event "routing recovery restored prior configuration kind=$RECOVERY_KIND"
-			if restart_if_enabled &&
-				cleanup_interrupted_metadata "$RECOVERY_KIND" "$RECOVERY_TOKEN" "$RECOVERY_FILE" "${RECOVERY_PREVIOUS:-}" &&
-				rm -f "$RECOVERY_MARKER"; then
-				rm -f "$RECOVERY_FILE" || true
-				log_event "routing recovery completed kind=$RECOVERY_KIND"
+		if [ "${RECOVERY_RESTART_ATTEMPTED:-0}" = 1 ]; then
+			# A controlled failure already restored the exact UCI file and tried
+			# its one bounded restart. Do not spend another timeout in this EXIT
+			# trap; leave the recovery marker for an explicit later recovery.
+			log_event "routing recovery restart already attempted kind=$RECOVERY_KIND; leaving recovery marker"
+			status=70
+		else
+			log_event "routing recovery started kind=$RECOVERY_KIND reason=interrupted status=$status"
+			if restore_config_checked "$RECOVERY_FILE" "$RECOVERY_TOKEN" "$RECOVERY_HASH"; then
+				log_event "routing recovery restored prior configuration kind=$RECOVERY_KIND"
+				if restart_restored_config &&
+					cleanup_interrupted_metadata "$RECOVERY_KIND" "$RECOVERY_TOKEN" "$RECOVERY_FILE" "${RECOVERY_PREVIOUS:-}" &&
+					rm -f "$RECOVERY_MARKER"; then
+					rm -f "$RECOVERY_FILE" || true
+					log_event "routing recovery completed kind=$RECOVERY_KIND"
+				else
+					log_event "routing recovery restart or cleanup failed kind=$RECOVERY_KIND"
+					status=70
+				fi
 			else
-				log_event "routing recovery restart or cleanup failed kind=$RECOVERY_KIND"
+				log_event "routing recovery could not restore prior configuration kind=$RECOVERY_KIND"
+				[ "$ERROR_EMITTED" -eq 1 ] ||
+					json_error restore_failed 'An interrupted routing transaction could not restore the prior PassWall2 file exactly.'
 				status=70
 			fi
-		else
-			log_event "routing recovery could not restore prior configuration kind=$RECOVERY_KIND"
-			[ "$ERROR_EMITTED" -eq 1 ] ||
-				json_error restore_failed 'An interrupted routing transaction could not restore the prior PassWall2 file exactly.'
-			status=70
 		fi
 	fi
 	if [ "$status" -eq 70 ] && [ "$ERROR_EMITTED" -eq 0 ]; then
@@ -1173,9 +1182,15 @@ terminate_tree() {
 
 run_passwall_restart() {
 	local restart_pid elapsed status
-	# PassWall2 starts long-lived proxy processes. Do not let them inherit the
-	# transaction lock descriptor and keep every later operation busy.
-	"$PW_INIT" restart 9>&- >/dev/null 2>&1 &
+	# PassWall2 26.9.2's init wrapper holds fd 999 while it invokes app.sh.
+	# app.sh starts long-lived proxy processes, which can retain that descriptor
+	# and make later `init.d/passwall2 restart` calls exit without reloading.
+	# Run the same stop/start lifecycle directly under our private transaction
+	# lock, and close that lock before child processes are created.
+	(
+		"$PW_APP" stop &&
+		"$PW_APP" start
+	) 9>&- >/dev/null 2>&1 &
 	restart_pid=$!
 	log_event "passwall restart started pid=$restart_pid timeout=${PASSWALL_RESTART_TIMEOUT}s"
 	elapsed=0
@@ -1214,6 +1229,15 @@ restart_if_enabled() {
 		return "$status"
 	fi
 	return 0
+}
+
+restart_restored_config() {
+	# If this bounded restart also fails, the EXIT trap must not retry it a
+	# third time and outlast LuCI's RPC window. The recovery marker remains so
+	# the exact restored file can be recovered explicitly later.
+	RECOVERY_RESTART_ATTEMPTED=1
+	log_event 'routing recovery restarting restored PassWall2 configuration'
+	restart_if_enabled
 }
 
 install_config() {
@@ -1424,7 +1448,7 @@ apply_plan() {
 		if ! restore_config_checked "$backup" "$token" "$META_SOURCE_HASH"; then
 			die restore_failed 'PassWall2 verification failed and the prior file could not be restored exactly.' 70
 		fi
-		restart_if_enabled || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
+		restart_restored_config || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
 		disarm_recovery || die recovery_marker_failed 'The prior file was restored but the recovery marker could not be cleared.' 70
 		rm -f "$backup"
 		release_lock
@@ -1435,7 +1459,7 @@ apply_plan() {
 		if ! restore_config_checked "$backup" "$token" "$META_SOURCE_HASH"; then
 			die restore_failed 'PassWall2 restart failed and the prior file could not be restored exactly.' 70
 		fi
-		restart_if_enabled || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
+		restart_restored_config || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
 		disarm_recovery || die recovery_marker_failed 'The prior file was restored but the recovery marker could not be cleared.' 70
 		rm -f "$backup"
 		release_lock
@@ -1445,7 +1469,7 @@ apply_plan() {
 		if ! restore_config_checked "$backup" "$token" "$META_SOURCE_HASH"; then
 			die restore_failed 'PassWall2 changed during activation and the prior file could not be restored exactly.' 70
 		fi
-		restart_if_enabled || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
+		restart_restored_config || die restore_restart_failed 'The prior PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
 		disarm_recovery || die recovery_marker_failed 'The prior file was restored but the recovery marker could not be cleared.' 70
 		rm -f "$backup"
 		release_lock
@@ -1505,7 +1529,7 @@ rollback() {
 	if ! restart_if_enabled; then
 		restore_config_checked "$current" "$token" "$META_POST_HASH" ||
 			die restore_failed 'Rollback restart failed and the applied file could not be restored exactly.' 70
-		restart_if_enabled || die restore_restart_failed 'The applied PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
+		restart_restored_config || die restore_restart_failed 'The applied PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
 		disarm_recovery || die recovery_marker_failed 'The applied file was restored but the recovery marker could not be cleared.' 70
 		rm -f "$current"
 		release_lock
@@ -1517,7 +1541,7 @@ rollback() {
 		# an exact rollback.
 		restore_config_checked "$current" "$token" "$META_POST_HASH" ||
 			die restore_failed 'Rollback verification failed and the applied file could not be restored exactly.' 70
-		restart_if_enabled || die restore_restart_failed 'The applied PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
+		restart_restored_config || die restore_restart_failed 'The applied PassWall2 file was restored, but its service could not be restarted; recovery remains armed.' 70
 		disarm_recovery || die recovery_marker_failed 'The applied file was restored but the recovery marker could not be cleared.' 70
 		rm -f "$current"
 		release_lock

--- a/xray-mitm/files/usr/sbin/xray-mitmctl
+++ b/xray-mitm/files/usr/sbin/xray-mitmctl
@@ -444,7 +444,7 @@ case "${1:-}" in
 		case "${2:-}" in
 			inspect|recover) [ "$#" -eq 2 ] ;;
 			plan) [ "$#" -eq 3 ] && [ -f "$3" ] ;;
-			apply|rollback) [ "$#" -eq 3 ] && xray_mitm_valid_fingerprint "$3" ;;
+			apply|activation-status|rollback) [ "$#" -eq 3 ] && xray_mitm_valid_fingerprint "$3" ;;
 			*) false ;;
 		esac || { json_error "invalid passwall2 command or arguments"; exit 1; }
 		[ -x "$PASSWALL_HELPER" ] || { json_error "PassWall2 integration is unavailable"; exit 1; }


### PR DESCRIPTION
## What changed

Prepare v0.4.3 with the routed Basic and Advanced LuCI dashboard, PassWall2-style overview layout, visible app version, selective Google service routing, and refreshed documentation.

The routing update adds a separate Google Meet web and signaling MITM group with explicit Meet hostnames. Google Play, Android services, account sign-in, and YouTube controls remain separate VPN overrides. The recovery workflow now bounds PassWall2 restart handling, preserves exact rollback state, and records recovery events.

## Validation

- `sh scripts/validate-release.sh` passed locally.
- The exact GitHub validation failure was reproduced and fixed; the recovery timing test passes repeatedly.
- Frontend JavaScript syntax and state tests passed with the bundled Node.js runtime.
- GitHub Actions run `34700240995` passed both `validate` and `build` jobs.
- AX4200 live LuCI validation passed for all eight routed pages with zero browser console errors.
- A real Google Meet session loaded and remained usable through the selective Meet route.
- MITM service, listeners, routing, certificates, and existing PassWall2 state were preserved during testing.
- `CHANGELOG.md`, README files, advanced documentation, and the release testing workflow were updated.
- No private keys, credentials, router configurations, backups, or generated packages are included.
