### PR TITLE
Prepare v0.4.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-09-12
+
 ### Added
 
 - Add a separate Google Meet web and signaling route under MITM-Compatible
@@ -19,8 +21,6 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep routing recovery tests within a bounded time margin when PassWall2 takes
   longer than usual to restart during an apply operation.
-
-## [0.4.3] - 2026-09-11
 
 ### Changed
 


### PR DESCRIPTION
## What changed

Move the Google Meet routing and PassWall2 recovery notes from `Unreleased` into the dated `0.4.3` changelog section so the signed release workflow publishes complete release notes.

## Validation

- `sh scripts/check-release-version.sh . v0.4.3` passes.
- `sh scripts/release-notes.sh . v0.4.3` includes the Meet and recovery entries.
- `NODE_BIN=/Users/dude/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node sh scripts/validate-release.sh` passes.
- No package, service, router, certificate, or private-key files were changed.
